### PR TITLE
feat: add `settings_old` endpoint

### DIFF
--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1423,3 +1423,22 @@ export class BalancesMetaFailed extends BaseError {
     super(message, properties)
   }
 }
+
+export class LegacySettingsFetchFailed extends BaseError {
+  public name = 'LegacySettingsFetchFailed'
+  constructor(public message: string = 'Could not fetch legacy settings', properties?: any) {
+    super(message, properties)
+  }
+}
+export class LegacySettingFetchFailed extends BaseError {
+  public name = 'LegacySettingFetchFailed'
+  constructor(public message: string = 'Could not fetch one legacy settings object', properties?: any) {
+    super(message, properties)
+  }
+}
+export class LegacySettingUpdateFailed extends BaseError {
+  public name = 'LegacySettingUpdateFailed'
+  constructor(public message: string = 'Could not update one legacy settings object', properties?: any) {
+    super(message, properties)
+  }
+}

--- a/src/tillhub-js.ts
+++ b/src/tillhub-js.ts
@@ -552,6 +552,14 @@ export class TillhubClient extends events.EventEmitter {
   balances(): v1.Balances {
     return this.generateAuthenticatedInstance(v1.Balances)
   }
+
+  /**
+   * Create an authenticated LegacySettings instance
+   *
+   */
+  settings_old(): v0.LegacySettings {
+    return this.generateAuthenticatedInstance(v0.LegacySettings)
+  }
 }
 
 export class Tillhub extends TillhubClient {

--- a/src/v0/index.ts
+++ b/src/v0/index.ts
@@ -24,6 +24,7 @@ import { Print } from './print'
 import { Discounts } from './discounts'
 import { Messages } from './messages'
 import { Favourites } from './favourites'
+import { LegacySettings } from './settings_old'
 
 export {
   Auth,
@@ -53,5 +54,6 @@ export {
   Notifications,
   Print,
   Messages,
-  Favourites
+  Favourites,
+  LegacySettings
 }

--- a/src/v0/settings_old.ts
+++ b/src/v0/settings_old.ts
@@ -1,0 +1,129 @@
+import { Client } from '../client'
+import {
+  LegacySettingFetchFailed,
+  LegacySettingsFetchFailed,
+  LegacySettingUpdateFailed
+} from '../errors'
+
+export interface LegacySettingsOptions {
+  user?: string
+  base?: string
+}
+
+export interface LegacySetting {
+  id?: number,
+  product_number_length?: number,
+  require_cashier_pin?: number,
+  barcode_length?: number,
+  product_group_number_length?: number,
+  customer_number_length?: number,
+  show_product_number?: number,
+  show_product_group_number?: number,
+  cash_payment_type?: number,
+  login?: number,
+  auto_product_number_enabled?: number,
+  auto_product_group_number_enabled?: number,
+  auto_customer_number_enabled?: number,
+  auto_staff_number_enabled?: number,
+  staff_number_length?: number,
+  require_salesman_pin?: number,
+  zedas_url?: string,
+  templater_url?: string,
+  invoice_id?: number,
+  fleurop_voucher?: number,
+  print_without_tax_enabled?: number,
+  fa_transit_account?: string,
+  shop_url?: string,
+  franchise_id?: string,
+  updated_at?: string,
+  update_id?: number,
+  customer_number_type?: string,
+  supported_languages?: string,
+  skr_transit?: string
+}
+
+export interface LegacySettingsResponse {
+  data: LegacySetting[],
+  metadata: {
+    count: number
+  }
+}
+
+export interface LegacySettingResponse {
+  data: LegacySetting,
+  metadata: {
+    count: number
+  }
+}
+
+export class LegacySettings {
+  endpoint: string
+  http: Client
+  public options: LegacySettingsOptions
+
+  constructor(options: LegacySettingsOptions, http: Client) {
+    this.options = options
+    this.http = http
+
+    this.endpoint = '/api/v0/settings_old'
+    this.options.base = this.options.base || 'https://api.tillhub.com'
+  }
+
+  getAll(): Promise<LegacySettingsResponse> {
+    return new Promise(async (resolve, reject) => {
+
+      try {
+        let uri = `${this.options.base}${this.endpoint}/${this.options.user}`
+
+        const response = await this.http.getClient().get(uri)
+        if (response.status !== 200) {
+          return reject(new LegacySettingsFetchFailed(undefined, { status: response.status }))
+        }
+
+        return resolve({
+          data: response.data.results,
+          metadata: { count: response.data.count }
+        } as LegacySettingsResponse)
+      } catch (error) {
+        return reject(new LegacySettingsFetchFailed(undefined, { error }))
+      }
+    })
+  }
+
+  get(LegacySettingId: string): Promise<LegacySettingResponse> {
+    return new Promise(async (resolve, reject) => {
+      let uri = `${this.options.base}${this.endpoint}/${this.options.user}/${LegacySettingId}`
+
+      try {
+        const response = await this.http.getClient().get(uri)
+        response.status !== 200 &&
+        reject(new LegacySettingFetchFailed(undefined, { status: response.status }))
+
+        return resolve({
+          data: response.data.results[0] as LegacySetting,
+          msg: response.data.msg,
+          metadata: { count: response.data.count }
+        } as LegacySettingResponse)
+      } catch (error) {
+        return reject(new LegacySettingFetchFailed(undefined, { error }))
+      }
+    })
+  }
+
+  update(LegacySettingId: string, LegacySetting: LegacySetting): Promise<LegacySettingResponse> {
+    return new Promise(async (resolve, reject) => {
+      const uri = `${this.options.base}${this.endpoint}/${this.options.user}/${LegacySettingId}`
+      try {
+        const response = await this.http.getClient().patch(uri, LegacySetting)
+
+        return resolve({
+          data: response.data.results[0] as LegacySetting,
+          metadata: { count: response.data.count }
+        } as LegacySettingResponse)
+      } catch (error) {
+        return reject(new LegacySettingUpdateFailed(undefined, { error }))
+      }
+    })
+  }
+
+}


### PR DESCRIPTION
* included getAll, get, update
* no tests, as it's fairly simple and only a temporary solution until migration is done / legacy support dropped