### PR TITLE
feat(document-export): add metric function for DataDog

### DIFF
--- a/src/v0/document_exports.ts
+++ b/src/v0/document_exports.ts
@@ -43,6 +43,19 @@ export interface DocumentExport {
   }
 }
 
+export interface DocumentExportsMetric {
+  tags: {
+    operation: string
+    documentType: string
+    result: 'success' | 'error'
+  }
+}
+
+export interface DocumentExportsMetricResponse {
+  data: DocumentExportsMetric
+  metadata: Record<string, unknown>
+}
+
 export class DocumentExports extends ThBaseHandler {
   public static baseEndpoint = '/api/v0/documents/exports'
   endpoint: string
@@ -110,6 +123,22 @@ export class DocumentExports extends ThBaseHandler {
       throw new DocumentExportsMetaFailed(error.message, { error })
     }
   }
+
+  async metric (metric: DocumentExportsMetric): Promise<DocumentExportsMetricResponse> {
+    const uri = this.uriHelper.generateBaseUri('/metric')
+    try {
+      const response = await this.http.getClient().post(uri, metric)
+      if (response.status !== 200) {
+        throw new DocumentExportsMetricFailed(undefined, { status: response.status })
+      }
+      return {
+        data: response.data,
+        metadata: {}
+      }
+    } catch (error: any) {
+      throw new DocumentExportsMetricFailed(error.message, { error })
+    }
+  }
 }
 
 export class DocumentExportsGetFailed extends BaseError {
@@ -131,5 +160,16 @@ export class DocumentExportsMetaFailed extends BaseError {
   ) {
     super(message, properties)
     Object.setPrototypeOf(this, DocumentExportsMetaFailed.prototype)
+  }
+}
+
+export class DocumentExportsMetricFailed extends BaseError {
+  public name = 'DocumentExportsMetricFailed'
+  constructor (
+    public message: string = 'Could not send document exports metric',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, DocumentExportsMetricFailed.prototype)
   }
 }

--- a/test/document_exports/metrix.test.ts
+++ b/test/document_exports/metrix.test.ts
@@ -1,0 +1,130 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { TillhubClient, v0 } from '../../src/tillhub-js'
+import { DocumentExportsMetric, DocumentExportsMetricResponse } from '../../src/v0/document_exports'
+dotenv.config()
+
+const user = {
+  username: 'test@example.com',
+  password: '12345678',
+  clientAccount: 'someuuid',
+  apiKey: '12345678'
+}
+
+if (process.env.SYSTEM_TEST) {
+  user.username = process.env.SYSTEM_TEST_USERNAME ?? user.username
+  user.password = process.env.SYSTEM_TEST_PASSWORD ?? user.password
+  user.clientAccount = process.env.SYSTEM_TEST_CLIENT_ACCOUNT_ID ?? user.clientAccount
+  user.apiKey = process.env.SYSTEM_TEST_API_KEY ?? user.apiKey
+}
+
+const legacyId = '4564'
+
+const metricQuery = {
+  tags: {
+    operation: 'download',
+    documentType: 'TransactionReceipt',
+    result: 'success'
+  }
+} as DocumentExportsMetric
+
+const metricResponse = {} as DocumentExportsMetricResponse
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+describe('v0: Document Exports: can send metric to API', () => {
+  it("Tillhub's Document exports metric are instantiable", async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock.onPost(`https://api.tillhub.com/api/v0/documents/exports/${legacyId}/metric`).reply(() => {
+        return [
+          200,
+          metricResponse
+        ]
+      })
+    }
+
+    const options = {
+      credentials: {
+        username: user.username,
+        password: user.password
+      },
+      base: process.env.TILLHUB_BASE
+    }
+
+    const th = new TillhubClient()
+
+    th.init(options)
+    await th.auth.loginUsername({
+      username: user.username,
+      password: user.password
+    })
+
+    const documentExports = th.documentExports()
+
+    expect(documentExports).toBeInstanceOf(v0.DocumentExports)
+
+    const { data } = await th.documentExports().metric(metricQuery)
+
+    expect(data).toEqual(metricResponse)
+  })
+
+  it('rejects on status codes that are not 200', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock.onPost(`https://api.tillhub.com/api/v0/documents/exports/${legacyId}/metric`).reply(() => {
+        return [302]
+      })
+    }
+
+    const options = {
+      credentials: {
+        username: user.username,
+        password: user.password
+      },
+      base: process.env.TILLHUB_BASE
+    }
+
+    const th = new TillhubClient()
+
+    th.init(options)
+    await th.auth.loginUsername({
+      username: user.username,
+      password: user.password
+    })
+
+    try {
+      await th.documentExports().metric(metricQuery)
+    } catch (err: any) {
+      expect(err.name).toBe('DocumentExportsMetricFailed')
+    }
+  })
+})


### PR DESCRIPTION
A new API to send metrics to the DataDog backend via normal API