### PR TITLE
feat(iamApiKeys): add IamApiKeys class and methods for managing API keys - UOD-1490

### DIFF
--- a/src/tillhub-js.ts
+++ b/src/tillhub-js.ts
@@ -350,6 +350,14 @@ export class TillhubClient extends events.EventEmitter {
   }
 
   /**
+     * Create an authenticated api keys instance
+     *
+     */
+  iamApiKeys (): v0.IamApiKeys {
+    return this.generateAuthenticatedInstance(v0.IamApiKeys)
+  }
+
+  /**
    * Create an authenticated configurations instance
    *
    */

--- a/src/v0/iam_api_keys.ts
+++ b/src/v0/iam_api_keys.ts
@@ -1,0 +1,169 @@
+
+import { Client } from '../client'
+import { BaseError } from '../errors/baseError'
+import { UriHelper } from '../uri-helper'
+import { ThBaseHandler } from '../base'
+
+export interface IamApiKeysOptions {
+  user?: string
+  base?: string
+}
+
+export interface IamApiKeysResponse {
+  data: MerchantApiKey[]
+  metadata: Record<string, unknown>
+  next?: () => Promise<IamApiKeysResponse>
+}
+
+export interface IamApiKeysPrivateKeyResponse {
+  privateKey?: string
+}
+
+export interface MerchantApiKey {
+  publicKey?: string
+  secureLevel?: string
+  alias?: string
+  productType?: string
+  keyPairState?: string
+  paymentTypes?: MerchantApiKeyPaymentType[]
+}
+
+export interface MerchantApiKeyPaymentType {
+  type?: string
+  allowCustomerTypes?: string
+  allowCreditTransaction?: string
+  supports?: MerchantApiKeyScope[]
+}
+
+export interface MerchantApiKeyScope {
+  channel?: string
+  pmpId?: string
+  brands?: string[]
+  currency?: string[]
+  countries?: string[]
+}
+
+export interface IamApiKeysQueryHandler {
+  limit?: number
+  uri?: string
+  query?: IamApiKeysQuery
+  orderFields?: string[] | string
+}
+
+export interface IamApiKeysQuery extends MerchantApiKey {
+  deleted?: boolean
+  active?: boolean
+  q?: string
+}
+
+export class IamApiKeys extends ThBaseHandler {
+  public static baseEndpoint = '/api/v0/iam/api-keys'
+  endpoint: string
+  http: Client
+  public options: IamApiKeysOptions
+  public uriHelper: UriHelper
+
+  constructor (options: IamApiKeysOptions, http: Client) {
+    super(http, { endpoint: IamApiKeys.baseEndpoint, base: options.base ?? 'https://api.tillhub.com' })
+    this.options = options
+    this.http = http
+
+    this.endpoint = IamApiKeys.baseEndpoint
+    this.options.base = this.options.base ?? 'https://api.tillhub.com'
+    this.uriHelper = new UriHelper(this.endpoint, this.options)
+  }
+
+  async getAll (query?: IamApiKeysQueryHandler | undefined): Promise<IamApiKeysResponse> {
+    let next
+    const base = this.uriHelper.generateBaseUri()
+    const uri = this.uriHelper.generateUriWithQuery(base, query)
+
+    try {
+      const response = await this.http.getClient().get(uri)
+      if (response.status !== 200) {
+        throw new IamApiKeysFetchFailed(undefined, { status: response.status })
+      }
+
+      if (response.data.cursors?.after) {
+        next = (): Promise<IamApiKeysResponse> => this.getAll({ uri: response.data.cursors.after })
+      }
+
+      return {
+        data: response.data.results as MerchantApiKey[],
+        metadata: { cursor: response.data.cursors },
+        next
+      }
+    } catch (error: any) {
+      throw new IamApiKeysFetchFailed(error.msg, { error })
+    }
+  }
+
+  async getPrivateKey (publicKey: string): Promise<IamApiKeysPrivateKeyResponse> {
+    const base = this.uriHelper.generateBaseUri('/private-key')
+    const uri = this.uriHelper.generateUriWithQuery(base)
+
+    try {
+      const response = await this.http.getClient().post(uri, { publicKey })
+      if (response.status !== 200) {
+        throw new IamApiKeysPrivateKeyFetchFailed(undefined, { status: response.status })
+      }
+
+      return {
+        privateKey: response.data.results[0].privateKey as string
+      }
+    } catch (error: any) {
+      throw new IamApiKeysPrivateKeyFetchFailed(error.msg, { error })
+    }
+  }
+
+  async meta (query?: IamApiKeysQueryHandler | undefined): Promise<IamApiKeysResponse> {
+    try {
+      const base = this.uriHelper.generateBaseUri('/meta')
+      const uri = this.uriHelper.generateUriWithQuery(base, query)
+
+      const response = await this.http.getClient().get(uri)
+
+      if (response.status !== 200) throw new IamApiKeysMetaFailed()
+
+      return {
+        data: response.data.results[0],
+        metadata: { count: response.data.count }
+      }
+    } catch (error: any) {
+      throw new IamApiKeysMetaFailed(error.msg, { error })
+    }
+  }
+}
+
+export class IamApiKeysFetchFailed extends BaseError {
+  public name = 'IamApiKeysFetchFailed'
+  constructor (
+    public message: string = 'Could not fetch iam roles',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, IamApiKeysFetchFailed.prototype)
+  }
+}
+
+export class IamApiKeysMetaFailed extends BaseError {
+  public name = 'IamApiKeysMetaFailed'
+  constructor (
+    public message: string = 'Could not fetch meta api keys',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, IamApiKeysMetaFailed.prototype)
+  }
+}
+
+export class IamApiKeysPrivateKeyFetchFailed extends BaseError {
+  public name = 'IamApiKeysPrivateKeyFetchFailed'
+  constructor (
+    public message: string = 'Could not private key',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, IamApiKeysMetaFailed.prototype)
+  }
+}

--- a/src/v0/index.ts
+++ b/src/v0/index.ts
@@ -14,6 +14,7 @@ import { Configurations } from './configurations'
 import { InventoryConfiguration } from './inventory_configuration'
 import { Users } from './users'
 import { IamUsers } from './iam_users'
+import { IamApiKeys } from './iam_api_keys'
 import { IamUserGroups } from './iam_user_groups'
 import { IamRoles } from './iam_roles'
 import { IamPermissions } from './iam_permissions'
@@ -104,6 +105,7 @@ export {
   InventoryConfiguration,
   Users,
   IamUsers,
+  IamApiKeys,
   IamUserGroups,
   IamRoles,
   IamPermissions,

--- a/test/iam_api_keys/get-all.test.ts
+++ b/test/iam_api_keys/get-all.test.ts
@@ -1,0 +1,84 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { v0 } from '../../src/tillhub-js'
+import { initThInstance } from '../util'
+dotenv.config()
+
+const legacyId = '4564'
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+describe('v0: IamApiKeys: can get all users', () => {
+  it("Tillhub's iam api keys are instantiable", async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock
+        .onGet(`https://api.tillhub.com/api/v0/iam/api-keys/${legacyId}`)
+        .reply(() => {
+          return [
+            200,
+            {
+              count: 1,
+              results: [{}]
+            }
+          ]
+        })
+    }
+
+    const th = await initThInstance()
+
+    const IamApiKeys = th.iamApiKeys()
+
+    expect(IamApiKeys).toBeInstanceOf(v0.IamApiKeys)
+
+    const { data } = await IamApiKeys.getAll()
+
+    expect(Array.isArray(data)).toBe(true)
+  })
+
+  it('rejects on status codes that are not 200', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock
+        .onGet(`https://api.tillhub.com/api/v0/iam/api-keys§/${legacyId}`)
+        .reply(() => {
+          return [205]
+        })
+    }
+
+    try {
+      const th = await initThInstance()
+      await th.iamApiKeys().getAll()
+    } catch (err: any) {
+      expect(err.name).toBe('IamApiKeysFetchFailed')
+    }
+  })
+})

--- a/test/iam_api_keys/get-private-key.test.ts
+++ b/test/iam_api_keys/get-private-key.test.ts
@@ -1,0 +1,84 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { v0 } from '../../src/tillhub-js'
+import { initThInstance } from '../util'
+dotenv.config()
+
+const legacyId = '4564'
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+const iamPrivateKey = {
+  privateKey: '123'
+}
+
+describe('v0: IamApiKeys: can get private key', () => {
+  it("Tillhub's iam api keys are instantiable", async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock.onPost(`https://api.tillhub.com/api/v0/iam/api-keys/${legacyId}/private-key`).reply(() => {
+        return [
+          200,
+          {
+            count: 1,
+            results: [{ privateKey: '123' }]
+          }
+        ]
+      })
+    }
+
+    const th = await initThInstance()
+
+    const iamApiKeys = th.iamApiKeys()
+
+    expect(iamApiKeys).toBeInstanceOf(v0.IamApiKeys)
+
+    const result = await iamApiKeys.getPrivateKey(iamPrivateKey.privateKey)
+
+    expect(result).toMatchObject(iamPrivateKey)
+  })
+
+  it('rejects on status codes that are not 200', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock.onPost(`https://api.tillhub.com/api/v0/iam/api-keys/${legacyId}/private-key`).reply(() => {
+        return [205]
+      })
+    }
+
+    try {
+      const th = await initThInstance()
+      await th.iamApiKeys().getPrivateKey(iamPrivateKey.privateKey)
+    } catch (err: any) {
+      expect(err.name).toBe('IamApiKeysPrivateKeyFetchFailed')
+    }
+  })
+})

--- a/test/iam_api_keys/meta.test.ts
+++ b/test/iam_api_keys/meta.test.ts
@@ -1,0 +1,84 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { v0 } from '../../src/tillhub-js'
+import { initThInstance } from '../util'
+dotenv.config()
+
+const legacyId = '4564'
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+describe('v0: IamApiKeys: can get meta users', () => {
+  it("Tillhub's iam users are instantiable", async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock
+        .onGet(`https://api.tillhub.com/api/v0/iam/api-keys/${legacyId}/meta`)
+        .reply(() => {
+          return [
+            200,
+            {
+              count: 1,
+              results: [{}]
+            }
+          ]
+        })
+    }
+
+    const th = await initThInstance()
+
+    const IamApiKeys = th.iamApiKeys()
+
+    expect(IamApiKeys).toBeInstanceOf(v0.IamApiKeys)
+
+    const { data } = await IamApiKeys.meta()
+
+    expect(Array.isArray(data)).toBe(false)
+  })
+
+  it('rejects on status codes that are not 200', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock
+        .onGet(`https://api.tillhub.com/api/v0/iam/api-keys/${legacyId}/meta`)
+        .reply(() => {
+          return [205]
+        })
+    }
+
+    try {
+      const th = await initThInstance()
+      await th.iamApiKeys().meta()
+    } catch (err: any) {
+      expect(err.name).toBe('IamApiKeysMetaFailed')
+    }
+  })
+})


### PR DESCRIPTION
- Introduced the IamApiKeys class with methods to fetch all API keys, retrieve private keys, and get metadata.
- Added iamApiKeys method to TillhubClient for creating an authenticated instance.
- Implemented tests for the new IamApiKeys functionality, ensuring proper instantiation and error handling.