### PR TITLE
fix(suppliers): fix not matching cursor variable (UNTIL-15108)

### DIFF
--- a/src/v0/suppliers.ts
+++ b/src/v0/suppliers.ts
@@ -172,13 +172,13 @@ export class Suppliers extends ThBaseHandler {
         throw new SuppliersFetchFailed(undefined, { status: response.status })
       }
 
-      if (response.data.cursor?.next) {
-        next = (): Promise<SuppliersResponse> => this.getAll({ uri: response.data.cursor.next })
+      if (response.data.cursors?.next) {
+        next = (): Promise<SuppliersResponse> => this.getAll({ uri: response.data.cursors.next })
       }
 
       return {
         data: response.data.results,
-        metadata: { cursor: response.data.cursor },
+        metadata: { cursor: response.data.cursors },
         next
       }
     } catch (error: any) {


### PR DESCRIPTION
## Summary

Fix wrong `cursor` variable to `cursors`, which led the `next` property to be `undifined.`
Leading to the page `/supplier-management/suppliers` not fetching the next items, when clicking on the next pagination page.

See below "Additional Information" for how to reproduce the bug locally.

**Some extra thoughts on this one:**
I am pretty sure that `cursor` was once the correct variable and assume that BE has changed at some point, without FE beeing updated accordingly, leading to this bug.

It might be worth it to go through the other endpoints, if there are more mismatches. But that would be out of scope and should be its own investigating task.


## Tickets

[UNTIL-15108](https://unz.atlassian.net/browse/UNTIL-15108)

## Additional Information

This Bug can be reproduce locally, with the following steps:

in code:
- open `apps/tillhub/views/supplier-management/suppliers/all.vue` and set `:resource-limit="100"` to `:resource-limit="20"`

in Tillhub Dashboard:
- create around 27 suppliers
- set the pagination limit to "20" items per page
- clicking on page 2 does not show the remaining 7

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / Code cleanup


## Known Issues

~

## Design Documentation

~

[UNTIL-15108]: https://unz.atlassian.net/browse/UNTIL-15108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ