### PR TITLE
fix(suppliers): update outdated  api property (UNTIL-15108)

### DIFF
--- a/src/v0/suppliers.ts
+++ b/src/v0/suppliers.ts
@@ -172,8 +172,8 @@ export class Suppliers extends ThBaseHandler {
         throw new SuppliersFetchFailed(undefined, { status: response.status })
       }
 
-      if (response.data.cursors?.next) {
-        next = (): Promise<SuppliersResponse> => this.getAll({ uri: response.data.cursors.next })
+      if (response.data.cursors?.after) {
+        next = (): Promise<SuppliersResponse> => this.getAll({ uri: response.data.cursors.after })
       }
 
       return {


### PR DESCRIPTION
## Summary

Fixes a mismatch of API variable name.
The API endpoint has change the prop from `next` to `after`, which we now need to update here in the sdk as well

## Tickets

[UNTIL-15108](https://unz.atlassian.net/browse/UNTIL-15108)

## Additional Information

~

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / Code cleanup


## Known Issues

~

## Design Documentation

~

[UNTIL-15108]: https://unz.atlassian.net/browse/UNTIL-15108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ