### PR TITLE
feat(mailjet): update credentialStatus response (UNTIL-15306)

### DIFF
--- a/src/v0/email.ts
+++ b/src/v0/email.ts
@@ -120,7 +120,6 @@ export class Email extends ThBaseHandler {
         status: response.data.status
       }
     } catch (error: any) {
-      console.log('error :>> ', error);
       throw new errors.EmailCredentialsSetFailed(error.message, { error })
     }
   }

--- a/src/v0/email.ts
+++ b/src/v0/email.ts
@@ -56,6 +56,11 @@ export interface CustomMailjetCredentialStatusResponse {
     isValid: boolean
     lastValidated: string | null
     error?: string
+    emailsUpdated: boolean
+    defaultSenderChanged: boolean
+    updateCode: 'NONE' | 'MAILJET_SENDER_LIST_SYNCED' | 'MAILJET_DEFAULT_SENDER_CHANGED'
+    previousDefaultEmail: string | null
+    newDefaultEmail: string | null
   }
   msg?: string
   status?: number
@@ -115,6 +120,7 @@ export class Email extends ThBaseHandler {
         status: response.data.status
       }
     } catch (error: any) {
+      console.log('error :>> ', error);
       throw new errors.EmailCredentialsSetFailed(error.message, { error })
     }
   }


### PR DESCRIPTION
## Summary

Update type definition of CustomMailjetCredentialStatusResponse, according to new Backend response.

## Tickets

[UNTIL-15306](https://unz.atlassian.net/browse/UNTIL-15306)

## Additional Information

~

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / Code cleanup


## Known Issues

~

## Design Documentation

~

[UNTIL-15306]: https://unz.atlassian.net/browse/UNTIL-15306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ