### PR TITLE
feat(checkout_questions): add new configurations bulk endpoints (UNTIL-15270)

### DIFF
--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -739,6 +739,28 @@ export class ConfigurationDeleteFailed extends BaseError {
   }
 }
 
+export class ConfigurationBulkFetchFailed extends BaseError {
+  public name = 'ConfigurationBulkFetchFailed'
+  constructor (
+    public message: string = 'Could not bulk fetch configurations',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, ConfigurationBulkFetchFailed.prototype)
+  }
+}
+
+export class ConfigurationBulkUpdateFailed extends BaseError {
+  public name = 'ConfigurationBulkUpdateFailed'
+  constructor (
+    public message: string = 'Could not bulk update configurations',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, ConfigurationBulkUpdateFailed.prototype)
+  }
+}
+
 export class DiscountsFetchFailed extends BaseError {
   public name = 'DiscountsFetchFailed'
   constructor (

--- a/src/v0/configurations.ts
+++ b/src/v0/configurations.ts
@@ -30,6 +30,30 @@ export interface ConfigurationResponse {
   msg?: string
 }
 
+export interface BulkFetchRequestBody {
+  sections?: string[]
+  owners?: string[]
+}
+
+export interface BulkFetchResponse {
+  data: Configuration[]
+  metadata?: Record<string, unknown>
+}
+
+export interface BulkUpdateRequestBody {
+  configurations: Configuration[]
+}
+
+export interface BulkUpdateResult {
+  id: string
+  success: boolean
+}
+
+export interface BulkUpdateResponse {
+  data: BulkUpdateResult[]
+  metadata?: Record<string, unknown>
+}
+
 export interface Configuration {
   id?: string
   vouchers?: Record<string, unknown>
@@ -207,6 +231,42 @@ export class Configurations extends ThBaseHandler {
       }
     } catch (error: any) {
       throw new errors.ConfigurationDeleteFailed(error.message, { error })
+    }
+  }
+
+  async bulkFetch (body: BulkFetchRequestBody): Promise<BulkFetchResponse> {
+    try {
+      const uri = this.uriHelper.generateBaseUri('/bulk-fetch')
+      const response = await this.http.getClient().post(uri, body)
+
+      if (response.status !== 200) {
+        throw new errors.ConfigurationBulkFetchFailed(undefined, { status: response.status })
+      }
+
+      return {
+        data: response.data.results as Configuration[],
+        metadata: response.data.metadata
+      }
+    } catch (error: any) {
+      throw new errors.ConfigurationBulkFetchFailed(error.message, { error })
+    }
+  }
+
+  async bulkUpdate (body: BulkUpdateRequestBody): Promise<BulkUpdateResponse> {
+    try {
+      const uri = this.uriHelper.generateBaseUri('/bulk-update')
+      const response = await this.http.getClient().patch(uri, body)
+
+      if (response.status !== 200) {
+        throw new errors.ConfigurationBulkUpdateFailed(undefined, { status: response.status })
+      }
+
+      return {
+        data: response.data.results as BulkUpdateResult[],
+        metadata: response.data.metadata
+      }
+    } catch (error: any) {
+      throw new errors.ConfigurationBulkUpdateFailed(error.message, { error })
     }
   }
 }

--- a/test/configurations/bulk-fetch.test.ts
+++ b/test/configurations/bulk-fetch.test.ts
@@ -1,0 +1,143 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { TillhubClient, v0 } from '../../src/tillhub-js'
+dotenv.config()
+
+const user = {
+  username: 'test@example.com',
+  password: '12345678',
+  clientAccount: 'someuuid',
+  apiKey: '12345678'
+}
+
+if (process.env.SYSTEM_TEST) {
+  user.username = process.env.SYSTEM_TEST_USERNAME ?? user.username
+  user.password = process.env.SYSTEM_TEST_PASSWORD ?? user.password
+  user.clientAccount = process.env.SYSTEM_TEST_CLIENT_ACCOUNT_ID ?? user.clientAccount
+  user.apiKey = process.env.SYSTEM_TEST_API_KEY ?? user.apiKey
+}
+
+const legacyId = '4564'
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+describe('v0: Configurations: can bulk fetch', () => {
+  it('Tillhub\'s Configurations bulk fetch returns configurations', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock.onPost(`https://api.tillhub.com/api/v0/configurations/${legacyId}/bulk-fetch`).reply(() => {
+        return [
+          200,
+          {
+            results: [
+              {
+                id: 'config-1',
+                owner: 'owner-1',
+                settings: { someSetting: true },
+                features: { someFeature: false }
+              },
+              {
+                id: 'config-2',
+                owner: 'owner-2',
+                settings: { someSetting: false },
+                features: { someFeature: true }
+              }
+            ],
+            metadata: {}
+          }
+        ]
+      })
+    }
+
+    const options = {
+      credentials: {
+        username: user.username,
+        password: user.password
+      },
+      base: process.env.TILLHUB_BASE
+    }
+
+    const th = new TillhubClient()
+
+    th.init(options)
+    await th.auth.loginUsername({
+      username: user.username,
+      password: user.password
+    })
+
+    const configurations = th.configurations()
+
+    expect(configurations).toBeInstanceOf(v0.Configurations)
+
+    const { data } = await configurations.bulkFetch({
+      sections: ['settings', 'features'],
+      owners: ['owner-1', 'owner-2']
+    })
+
+    expect(Array.isArray(data)).toBe(true)
+    expect(data.length).toBe(2)
+    expect(data[0].id).toBe('config-1')
+    expect(data[0].owner).toBe('owner-1')
+  })
+
+  it('rejects on status codes that are not 200', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+      mock.onPost(`https://api.tillhub.com/api/v0/configurations/${legacyId}/bulk-fetch`).reply(() => {
+        return [400]
+      })
+    }
+
+    const options = {
+      credentials: {
+        username: user.username,
+        password: user.password
+      },
+      base: process.env.TILLHUB_BASE
+    }
+
+    const th = new TillhubClient()
+
+    th.init(options)
+    await th.auth.loginUsername({
+      username: user.username,
+      password: user.password
+    })
+
+    try {
+      await th.configurations().bulkFetch({
+        sections: ['settings'],
+        owners: ['owner-1']
+      })
+    } catch (err: any) {
+      expect(err.name).toBe('ConfigurationBulkFetchFailed')
+    }
+  })
+})

--- a/test/configurations/bulk-update.test.ts
+++ b/test/configurations/bulk-update.test.ts
@@ -1,0 +1,155 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { TillhubClient, v0 } from '../../src/tillhub-js'
+dotenv.config()
+
+const user = {
+  username: 'test@example.com',
+  password: '12345678',
+  clientAccount: 'someuuid',
+  apiKey: '12345678'
+}
+
+if (process.env.SYSTEM_TEST) {
+  user.username = process.env.SYSTEM_TEST_USERNAME ?? user.username
+  user.password = process.env.SYSTEM_TEST_PASSWORD ?? user.password
+  user.clientAccount = process.env.SYSTEM_TEST_CLIENT_ACCOUNT_ID ?? user.clientAccount
+  user.apiKey = process.env.SYSTEM_TEST_API_KEY ?? user.apiKey
+}
+
+const legacyId = '4564'
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+describe('v0: Configurations: can bulk update', () => {
+  it('Tillhub\'s Configurations bulk update returns results', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock.onPatch(`https://api.tillhub.com/api/v0/configurations/${legacyId}/bulk-update`).reply(() => {
+        return [
+          200,
+          {
+            results: [
+              {
+                id: 'config-1',
+                success: true
+              },
+              {
+                id: 'config-2',
+                success: true
+              }
+            ],
+            metadata: {}
+          }
+        ]
+      })
+    }
+
+    const options = {
+      credentials: {
+        username: user.username,
+        password: user.password
+      },
+      base: process.env.TILLHUB_BASE
+    }
+
+    const th = new TillhubClient()
+
+    th.init(options)
+    await th.auth.loginUsername({
+      username: user.username,
+      password: user.password
+    })
+
+    const configurations = th.configurations()
+
+    expect(configurations).toBeInstanceOf(v0.Configurations)
+
+    const { data } = await configurations.bulkUpdate({
+      configurations: [
+        {
+          id: 'config-1',
+          owner: 'owner-1',
+          features: { someFeature: true }
+        },
+        {
+          id: 'config-2',
+          features: { someFeature: false }
+        }
+      ]
+    })
+
+    expect(Array.isArray(data)).toBe(true)
+    expect(data.length).toBe(2)
+    expect(data[0].id).toBe('config-1')
+    expect(data[0].success).toBe(true)
+    expect(data[1].id).toBe('config-2')
+    expect(data[1].success).toBe(true)
+  })
+
+  it('rejects on status codes that are not 200', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+      mock.onPatch(`https://api.tillhub.com/api/v0/configurations/${legacyId}/bulk-update`).reply(() => {
+        return [400]
+      })
+    }
+
+    const options = {
+      credentials: {
+        username: user.username,
+        password: user.password
+      },
+      base: process.env.TILLHUB_BASE
+    }
+
+    const th = new TillhubClient()
+
+    th.init(options)
+    await th.auth.loginUsername({
+      username: user.username,
+      password: user.password
+    })
+
+    try {
+      await th.configurations().bulkUpdate({
+        configurations: [
+          {
+            id: 'config-1',
+            features: { someFeature: true }
+          }
+        ]
+      })
+    } catch (err: any) {
+      expect(err.name).toBe('ConfigurationBulkUpdateFailed')
+    }
+  })
+})
+


### PR DESCRIPTION
## Summary

Implementing two new bulk endpoints for configuration API.
Which will help us do bulk fetch/update for multiple registers on the new "pos => checkout-questions" page

## Tickets

[UNTIL-15270](https://unz.atlassian.net/browse/UNTIL-15270)

## Additional Information

[This Dashboard PR](https://github.com/tillhub/tillhub-dashboard/pull/4302) depends on this SDK PR

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / Code cleanup


## Known Issues

~

## Design Documentation

~

[UNTIL-15270]: https://unz.atlassian.net/browse/UNTIL-15270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ