### PR TITLE
feat(sale_streams): add SaleStreams class and related functionality

### DIFF
--- a/src/tillhub-js.ts
+++ b/src/tillhub-js.ts
@@ -438,6 +438,14 @@ export class TillhubClient extends events.EventEmitter {
   }
 
   /**
+   * Create an authenticated payment products instance
+   *
+   */
+  saleStreams (): v0.SaleStreams {
+    return this.generateAuthenticatedInstance(v0.SaleStreams)
+  }
+
+  /**
    * Create an authenticated devices instance
    *
    */

--- a/src/v0/index.ts
+++ b/src/v0/index.ts
@@ -20,6 +20,7 @@ import { IamRoles } from './iam_roles'
 import { IamPermissions } from './iam_permissions'
 import { IamMeClass } from './iam_me'
 import { PaymentProducts } from './payment_products'
+import { SaleStreams } from './sale_streams'
 import { Branches } from './branches'
 import { BranchGroups } from './branch_groups'
 import { Devices } from './devices'
@@ -116,6 +117,7 @@ export {
   IamPermissions,
   IamMeClass,
   PaymentProducts,
+  SaleStreams,
   Branches,
   BranchGroups,
   Devices,

--- a/src/v0/sale_streams.ts
+++ b/src/v0/sale_streams.ts
@@ -1,0 +1,81 @@
+
+import { Client } from '../client'
+import { BaseError } from '../errors/baseError'
+import { UriHelper } from '../uri-helper'
+import { ThBaseHandler } from '../base'
+
+export interface SaleStreamsOptions {
+  user?: string
+  base?: string
+}
+
+export interface SaleStreamsResponse {
+  data: SaleStream[]
+}
+
+export interface ErrorObject {
+  id: string
+  label: string
+  errorDetails: Record<string, unknown>
+}
+
+export interface SaleStream {
+  id?: string
+  active?: boolean
+  name?: string
+  type?: string
+  businessUnit?: BusinessUnit
+  keyPairIds?: string[]
+}
+
+export interface BusinessUnit {
+  unzerId?: string
+  type?: string
+}
+
+export class SaleStreams extends ThBaseHandler {
+  public static baseEndpoint = '/api/v0/sale-streams'
+  endpoint: string
+  http: Client
+  public options: SaleStreamsOptions
+  public uriHelper: UriHelper
+
+  constructor (options: SaleStreamsOptions, http: Client) {
+    super(http, { endpoint: SaleStreams.baseEndpoint, base: options.base ?? 'https://api.tillhub.com' })
+    this.options = options
+    this.http = http
+
+    this.endpoint = SaleStreams.baseEndpoint
+    this.options.base = this.options.base ?? 'https://api.tillhub.com'
+    this.uriHelper = new UriHelper(this.endpoint, this.options)
+  }
+
+  async getMotoSaleStreams (): Promise<SaleStreamsResponse> {
+    const base = this.uriHelper.generateBaseUri()
+    const uri = this.uriHelper.generateUriWithQuery(`${base}/moto`)
+
+    try {
+      const response = await this.http.getClient().get(uri)
+      if (response.status !== 200) {
+        throw new SaleStreamsFetchFailed(undefined, { status: response.status })
+      }
+
+      return {
+        data: response.data.results as SaleStream[]
+      }
+    } catch (error: any) {
+      throw new SaleStreamsFetchFailed(error.message, { error })
+    }
+  }
+}
+
+export class SaleStreamsFetchFailed extends BaseError {
+  public name = 'SaleStreamsFetchFailed'
+  constructor (
+    public message: string = 'Could not fetch payment products',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, SaleStreamsFetchFailed.prototype)
+  }
+}

--- a/test/sale_streams/get-all.test.ts
+++ b/test/sale_streams/get-all.test.ts
@@ -1,0 +1,94 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { v0 } from '../../src/tillhub-js'
+import { initThInstance } from '../util'
+
+dotenv.config()
+
+const legacyId = '4564'
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+const mockSaleStream = {
+  id: 'stream-123',
+  active: true,
+  name: 'Main Sales Stream',
+  type: 'online',
+  businessUnit: {
+    unzerId: 'unzer-123',
+    type: 'moto'
+  },
+  keyPairIds: ['key-1', 'key-2']
+}
+
+describe('v0: SaleStreams: can get MOTO sale streams', () => {
+  it("Tillhub's sale streams are instantiable", async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock.onGet(`https://api.tillhub.com/api/v0/sale-streams/${legacyId}/moto`).reply(() => {
+        return [
+          200,
+          {
+            count: 1,
+            results: [mockSaleStream]
+          }
+        ]
+      })
+    }
+
+    const th = await initThInstance()
+
+    const saleStreams = th.saleStreams()
+
+    expect(saleStreams).toBeInstanceOf(v0.SaleStreams)
+
+    const { data } = await saleStreams.getMotoSaleStreams()
+
+    expect(Array.isArray(data)).toBe(true)
+    expect(data).toContainEqual(mockSaleStream)
+  })
+
+  it('rejects on status codes that are not 200', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock.onGet(`https://api.tillhub.com/api/v0/sale-streams/${legacyId}/moto`).reply(() => {
+        return [404, { error: 'Not found' }]
+      })
+    }
+
+    try {
+      const th = await initThInstance()
+      await th.saleStreams().getMotoSaleStreams()
+    } catch (err: any) {
+      expect(err.name).toBe('SaleStreamsFetchFailed')
+    }
+  })
+})


### PR DESCRIPTION
- Introduced a new SaleStreams class for handling sale streams API interactions.
- Added a method to create an authenticated instance of SaleStreams in TillhubClient.
- Implemented a method to fetch MOTO sale streams with error handling.
- Included tests for SaleStreams functionality to ensure proper behavior.