### PR TITLE
feat(vouchers): add early return for no changes in patch operation (UNTIL-18152)

### DIFF
--- a/src/v0/vouchers.ts
+++ b/src/v0/vouchers.ts
@@ -277,6 +277,14 @@ export class Vouchers extends ThBaseHandler {
     try {
       const patch = diff(source, target, jsonPatchPathConverter)
 
+      // If no changes, return early without calling the API
+      if (patch.length === 0) {
+        return {
+          data: source,
+          metadata: { count: 1, patch }
+        }
+      }
+
       const response = await this.http.getClient()({
         method: 'PATCH',
         url: uri,

--- a/test/vouchers/patch.test.ts
+++ b/test/vouchers/patch.test.ts
@@ -98,6 +98,55 @@ describe('v0: vouchers: can patch one', () => {
     expect((data as any).id).toBe(voucherId)
   })
 
+  it('returns source data without API call when no changes', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      // No mock for PATCH - if it's called, the test will fail
+    }
+
+    const options = {
+      credentials: {
+        username: user.username,
+        password: user.password
+      },
+      base: process.env.TILLHUB_BASE
+    }
+
+    const th = new TillhubClient()
+
+    th.init(options)
+    await th.auth.loginUsername({
+      username: user.username,
+      password: user.password
+    })
+
+    const unchangedVoucher = {
+      id: voucherId,
+      amount: 9.99
+    }
+
+    const { data, metadata } = await th.vouchers().patch(unchangedVoucher as any, unchangedVoucher as any)
+
+    if (!metadata) throw new Error('metadata must be defined')
+
+    expect(metadata.patch).toEqual([])
+    expect(metadata.count).toBe(1)
+    expect((data as any).id).toBe(voucherId)
+    expect((data as any).amount).toBe(9.99)
+  })
+
   it('rejects on status codes that are not 200', async () => {
     if (process.env.SYSTEM_TEST !== 'true') {
       mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {


### PR DESCRIPTION
## Summary

Add early return for no changes in patch operation, to save unnecessary network request.

## Tickets

[UNTIL-18152](https://unz.atlassian.net/browse/UNTIL-18152)

## Additional Information

~

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / Code cleanup


## Known Issues

~

## Design Documentation

~


[UNTIL-18152]: https://unz.atlassian.net/browse/UNTIL-18152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ