### PR TITLE
feat(UNTIL-20267): add bookable_online to ServicesObject

### DIFF
--- a/src/v0/services.ts
+++ b/src/v0/services.ts
@@ -26,6 +26,9 @@ export interface ServicesObject {
   id?: string
   deleted?: boolean
   locations?: null | string[]
+  // Whether the service is exposed in Online Booking. Defaults to true server-side
+  // for reservation services; null/undefined for non-reservation product rows.
+  bookable_online?: boolean
 }
 
 export class Services extends ThBaseHandler {

--- a/test/services/create.test.ts
+++ b/test/services/create.test.ts
@@ -24,7 +24,8 @@ const legacyId = '4564'
 const serviceItem = {
   name: 'Test name',
   duration: 5,
-  linked_product: '0f20c60f-2ed9-4685-8cd1-23970071f7eb'
+  linked_product: '0f20c60f-2ed9-4685-8cd1-23970071f7eb',
+  bookable_online: true
 }
 
 beforeEach(() => {

--- a/test/services/put.test.ts
+++ b/test/services/put.test.ts
@@ -16,7 +16,8 @@ const serviceId = '0505ce68-9cd9-4b0c-ac5c-7cb6804e8956'
 const serviceItem = {
   name: 'Test name',
   duration: 5,
-  linked_product: '0f20c60f-2ed9-4685-8cd1-23970071f7eb'
+  linked_product: '0f20c60f-2ed9-4685-8cd1-23970071f7eb',
+  bookable_online: false
 }
 
 describe('v0: Services: can alter the service', () => {


### PR DESCRIPTION
## Summary

- Extend the v0 `ServicesObject` SDK type with the new optional `bookable_online?: boolean` field introduced server-side in [tillhub/tillhub-api#3453](https://github.com/tillhub/tillhub-api/pull/3453) (UNTIL-20265).
- Round-trip the field through existing `create` / `put` fixtures to assert it survives serialization on `POST` (default `true`) and `PUT` (toggle-off case).

## Context

Part of UNTIL-20267 (FE Dashboard) under parent story UNTIL-20258 *Manage Service Online Bookability*. The dashboard editor change in [tillhub/tillhub-dashboard](https://github.com/tillhub/tillhub-dashboard) will consume this type once a release is published.

## Test plan

- [x] `npx jest test/services` — all 6 tests in `create.test.ts` / `put.test.ts` / `get-services.test.ts` pass.
- [x] `eslint` clean on `src/v0/services.ts` and `test/services`.


Made with [Cursor](https://cursor.com)