### PR TITLE
feat(UNTIL-20270): add v1 ServiceSteps resource

### DIFF
--- a/src/tillhub-js.ts
+++ b/src/tillhub-js.ts
@@ -1234,6 +1234,14 @@ export class TillhubClient extends events.EventEmitter {
   }
 
   /**
+   * Create an authenticated ServiceSteps instance
+   *
+   */
+  serviceSteps (): v1.ServiceSteps {
+    return this.generateAuthenticatedInstance(v1.ServiceSteps)
+  }
+
+  /**
    * Create an authenticated Exports instance
    *
    */

--- a/src/v1/index.ts
+++ b/src/v1/index.ts
@@ -27,6 +27,7 @@ import { Contents } from './contents'
 import { ContentTemplates } from './content-templates'
 import { Import } from './import'
 import { SuppliersProductsRelation } from './suppliers_products_relation'
+import { ServiceSteps } from './service_steps'
 
 export {
   Auth,
@@ -58,7 +59,8 @@ export {
   Contents,
   ContentTemplates,
   Import,
-  SuppliersProductsRelation
+  SuppliersProductsRelation,
+  ServiceSteps
 }
 
 export interface AnalyticsHandlersV1Types {

--- a/src/v1/service_steps.ts
+++ b/src/v1/service_steps.ts
@@ -1,0 +1,233 @@
+import { Client } from '../client'
+import { UriHelper } from '../uri-helper'
+import { BaseError } from '../errors/baseError'
+import { ThBaseHandler } from '../base'
+
+export interface ServiceStepsOptions {
+  user?: string
+  base?: string
+}
+
+export interface ServiceStepsQuery {
+  q?: string
+  limit?: number
+  uri?: string
+  deleted?: boolean
+}
+
+export interface ServiceStepsResponse {
+  data: ServiceStep[]
+  metadata: Record<string, unknown>
+  next?: () => Promise<ServiceStepsResponse>
+}
+
+export interface ServiceStepResponse {
+  data?: ServiceStep
+  metadata?: {
+    count?: number
+  }
+  msg?: string
+}
+
+export interface ServiceStepLinkedService {
+  id: string
+  name: string
+}
+
+export interface ServiceStep {
+  id?: string
+  name: string
+  duration: number
+  active?: boolean
+  createdAt?: string
+  updatedAt?: string
+  deletedAt?: string | null
+  services?: ServiceStepLinkedService[]
+  servicesCount?: number
+}
+
+export class ServiceSteps extends ThBaseHandler {
+  public static baseEndpoint = '/api/v1/service-steps'
+  endpoint: string
+  http: Client
+  public options: ServiceStepsOptions
+  public uriHelper: UriHelper
+
+  constructor (options: ServiceStepsOptions, http: Client) {
+    super(http, {
+      endpoint: ServiceSteps.baseEndpoint,
+      base: options.base ?? 'https://api.tillhub.com'
+    })
+    this.options = options
+    this.http = http
+
+    this.endpoint = ServiceSteps.baseEndpoint
+    this.options.base = this.options.base ?? 'https://api.tillhub.com'
+    this.uriHelper = new UriHelper(this.endpoint, this.options)
+  }
+
+  async getAll (query?: ServiceStepsQuery | undefined): Promise<ServiceStepsResponse> {
+    let next
+
+    try {
+      const base = this.uriHelper.generateBaseUri()
+      const uri = this.uriHelper.generateUriWithQuery(base, query)
+
+      const response = await this.http.getClient().get(uri)
+
+      if (response.data.cursor?.next) {
+        next = (): Promise<ServiceStepsResponse> => this.getAll({ uri: response.data.cursor.next })
+      }
+
+      return {
+        data: response.data.results,
+        metadata: { count: response.data.count, cursor: response.data.cursor },
+        next
+      }
+    } catch (error: any) {
+      throw new ServiceStepsFetchAllFailed(error.message, { error })
+    }
+  }
+
+  async meta (): Promise<ServiceStepsResponse> {
+    try {
+      const uri = this.uriHelper.generateBaseUri('/meta')
+      const response = await this.http.getClient().get(uri)
+
+      if (response.status !== 200) throw new ServiceStepsMetaFailed()
+
+      return {
+        data: response.data.results,
+        metadata: { count: response.data.count }
+      }
+    } catch (error: any) {
+      throw new ServiceStepsMetaFailed(error.message, { error })
+    }
+  }
+
+  async get (serviceStepId: string): Promise<ServiceStepResponse> {
+    const uri = this.uriHelper.generateBaseUri(`/${serviceStepId}`)
+    try {
+      const response = await this.http.getClient().get(uri)
+      if (response.status !== 200) {
+        throw new ServiceStepFetchFailed(undefined, { status: response.status })
+      }
+
+      return {
+        data: response.data.results[0] as ServiceStep,
+        msg: response.data.msg,
+        metadata: { count: response.data.count }
+      }
+    } catch (error: any) {
+      throw new ServiceStepFetchFailed(error.message, { error })
+    }
+  }
+
+  async put (serviceStepId: string, serviceStep: ServiceStep): Promise<ServiceStepResponse> {
+    const uri = this.uriHelper.generateBaseUri(`/${serviceStepId}`)
+    try {
+      const response = await this.http.getClient().put(uri, serviceStep)
+
+      return {
+        data: response.data.results[0] as ServiceStep,
+        metadata: { count: response.data.count }
+      }
+    } catch (error: any) {
+      throw new ServiceStepPutFailed(error.message, { error })
+    }
+  }
+
+  async create (serviceStep: ServiceStep): Promise<ServiceStepResponse> {
+    const uri = this.uriHelper.generateBaseUri()
+    try {
+      const response = await this.http.getClient().post(uri, serviceStep)
+
+      return {
+        data: response.data.results[0] as ServiceStep,
+        metadata: { count: response.data.count }
+      }
+    } catch (error: any) {
+      throw new ServiceStepCreationFailed(error.message, { error })
+    }
+  }
+
+  async delete (serviceStepId: string): Promise<ServiceStepResponse> {
+    const uri = this.uriHelper.generateBaseUri(`/${serviceStepId}`)
+    try {
+      const response = await this.http.getClient().delete(uri)
+      if (response.status !== 200) throw new ServiceStepDeleteFailed()
+
+      return {
+        msg: response.data.msg
+      }
+    } catch (error: any) {
+      throw new ServiceStepDeleteFailed(error.message, { error })
+    }
+  }
+}
+
+export class ServiceStepsFetchAllFailed extends BaseError {
+  public name = 'ServiceStepsFetchAllFailed'
+  constructor (
+    public message: string = 'Could not fetch all service steps',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, ServiceStepsFetchAllFailed.prototype)
+  }
+}
+
+export class ServiceStepsMetaFailed extends BaseError {
+  public name = 'ServiceStepsMetaFailed'
+  constructor (
+    public message: string = 'Could not fetch service steps meta call',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, ServiceStepsMetaFailed.prototype)
+  }
+}
+
+export class ServiceStepFetchFailed extends BaseError {
+  public name = 'ServiceStepFetchFailed'
+  constructor (
+    public message: string = 'Could not fetch the service step',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, ServiceStepFetchFailed.prototype)
+  }
+}
+
+export class ServiceStepPutFailed extends BaseError {
+  public name = 'ServiceStepPutFailed'
+  constructor (
+    public message: string = 'Could not alter the service step',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, ServiceStepPutFailed.prototype)
+  }
+}
+
+export class ServiceStepCreationFailed extends BaseError {
+  public name = 'ServiceStepCreationFailed'
+  constructor (
+    public message: string = 'Could not create the service step',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, ServiceStepCreationFailed.prototype)
+  }
+}
+
+export class ServiceStepDeleteFailed extends BaseError {
+  public name = 'ServiceStepDeleteFailed'
+  constructor (
+    public message: string = 'Could not delete the service step',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, ServiceStepDeleteFailed.prototype)
+  }
+}

--- a/test/service_steps/create.test.ts
+++ b/test/service_steps/create.test.ts
@@ -1,0 +1,85 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { v1 } from '../../src/tillhub-js'
+import { initThInstance } from '../util'
+dotenv.config()
+
+const legacyId = '4564'
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+const serviceStep = {
+  name: 'Hair coloring',
+  duration: 30
+}
+
+describe('v1: ServiceSteps: can create one service step', () => {
+  it("Tillhub's service steps are instantiable", async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock.onPost(`https://api.tillhub.com/api/v1/service-steps/${legacyId}`).reply(() => {
+        return [
+          200,
+          {
+            count: 1,
+            results: [serviceStep]
+          }
+        ]
+      })
+    }
+
+    const th = await initThInstance()
+
+    const serviceSteps = th.serviceSteps()
+
+    expect(serviceSteps).toBeInstanceOf(v1.ServiceSteps)
+
+    const { data } = await serviceSteps.create(serviceStep)
+
+    expect(data).toMatchObject(serviceStep)
+  })
+
+  it('rejects on errored response', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock.onPost(`https://api.tillhub.com/api/v1/service-steps/${legacyId}`).reply(() => {
+        return [500]
+      })
+    }
+
+    try {
+      const th = await initThInstance()
+      await th.serviceSteps().create(serviceStep)
+    } catch (err: any) {
+      expect(err.name).toBe('ServiceStepCreationFailed')
+    }
+  })
+})

--- a/test/service_steps/delete.test.ts
+++ b/test/service_steps/delete.test.ts
@@ -1,0 +1,131 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { v1 } from '../../src/tillhub-js'
+import { initThInstance } from '../util'
+dotenv.config()
+
+const legacyId = '4564'
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+const serviceStepId = 'asdf5566'
+const respMsg = `Deleted service step ${serviceStepId}`
+
+describe('v1: ServiceSteps: can delete a service step', () => {
+  it("Tillhub's service steps are instantiable", async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock
+        .onDelete(`https://api.tillhub.com/api/v1/service-steps/${legacyId}/${serviceStepId}`)
+        .reply(() => {
+          return [
+            200,
+            {
+              msg: respMsg
+            }
+          ]
+        })
+    }
+
+    const th = await initThInstance()
+
+    const serviceSteps = th.serviceSteps()
+
+    expect(serviceSteps).toBeInstanceOf(v1.ServiceSteps)
+
+    const { msg } = await serviceSteps.delete(serviceStepId)
+
+    expect(msg).toEqual(respMsg)
+  })
+
+  it('rejects on errored response', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+      mock
+        .onDelete(`https://api.tillhub.com/api/v1/service-steps/${legacyId}/${serviceStepId}`)
+        .reply(() => {
+          return [500]
+        })
+    }
+
+    const th = await initThInstance()
+
+    try {
+      await th.serviceSteps().delete(serviceStepId)
+    } catch (err: any) {
+      expect(err.name).toBe('ServiceStepDeleteFailed')
+    }
+  })
+
+  it('surfaces blocking_services on 409 conflict', async () => {
+    if (process.env.SYSTEM_TEST === 'true') return
+
+    mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+      return [
+        200,
+        {
+          token: '',
+          user: {
+            id: '123',
+            legacy_id: legacyId
+          }
+        }
+      ]
+    })
+
+    const blockingServices = [
+      { id: 'svc-1', name: 'Hair coloring' },
+      { id: 'svc-2', name: 'Highlights' }
+    ]
+
+    mock
+      .onDelete(`https://api.tillhub.com/api/v1/service-steps/${legacyId}/${serviceStepId}`)
+      .reply(() => {
+        return [
+          409,
+          {
+            msg: 'Cannot delete service step while it is referenced by services',
+            blocking_services: blockingServices
+          }
+        ]
+      })
+
+    const th = await initThInstance()
+
+    try {
+      await th.serviceSteps().delete(serviceStepId)
+      throw new Error('expected delete to reject')
+    } catch (err: any) {
+      expect(err.name).toBe('ServiceStepDeleteFailed')
+      expect(err.properties.error.response.status).toBe(409)
+      expect(err.properties.error.response.data.blocking_services).toEqual(blockingServices)
+    }
+  })
+})

--- a/test/service_steps/get-all.test.ts
+++ b/test/service_steps/get-all.test.ts
@@ -1,0 +1,88 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { v1 } from '../../src/tillhub-js'
+import { initThInstance } from '../util'
+dotenv.config()
+
+const legacyId = '4564'
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+const serviceStep = {
+  id: 'a3a7d4f6-3b6f-4f6e-9b1a-1c3d6e8f9a0b',
+  name: 'Hair coloring',
+  duration: 30,
+  services: [{ id: 'svc-1', name: 'Hair coloring' }],
+  servicesCount: 1
+}
+
+describe('v1: ServiceSteps: can get all', () => {
+  it("Tillhub's ServiceSteps are instantiable", async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock.onGet(`https://api.tillhub.com/api/v1/service-steps/${legacyId}`).reply(() => {
+        return [
+          200,
+          {
+            count: 1,
+            results: [serviceStep]
+          }
+        ]
+      })
+    }
+
+    const th = await initThInstance()
+
+    const serviceSteps = th.serviceSteps()
+
+    expect(serviceSteps).toBeInstanceOf(v1.ServiceSteps)
+
+    const { data } = await serviceSteps.getAll()
+
+    expect(Array.isArray(data)).toBe(true)
+  })
+
+  it('rejects on errored response', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+      mock.onGet(`https://api.tillhub.com/api/v1/service-steps/${legacyId}`).reply(() => {
+        return [500]
+      })
+    }
+
+    const th = await initThInstance()
+
+    try {
+      await th.serviceSteps().getAll()
+    } catch (err: any) {
+      expect(err.name).toBe('ServiceStepsFetchAllFailed')
+    }
+  })
+})

--- a/test/service_steps/get.test.ts
+++ b/test/service_steps/get.test.ts
@@ -1,0 +1,96 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { v1 } from '../../src/tillhub-js'
+import { initThInstance } from '../util'
+dotenv.config()
+
+const legacyId = '4564'
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+const serviceStepId = 'f8314183-8199-4cb7-b152-04f6ad4ebc7e'
+const serviceStep = {
+  id: serviceStepId,
+  name: 'Hair coloring',
+  duration: 30,
+  services: [
+    { id: 'svc-1', name: 'Hair coloring' },
+    { id: 'svc-2', name: 'Highlights' }
+  ],
+  servicesCount: 2
+}
+
+describe('v1: ServiceSteps: can get one service step', () => {
+  it("Tillhub's service steps are instantiable", async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock
+        .onGet(`https://api.tillhub.com/api/v1/service-steps/${legacyId}/${serviceStepId}`)
+        .reply(() => {
+          return [
+            200,
+            {
+              count: 1,
+              results: [serviceStep]
+            }
+          ]
+        })
+    }
+
+    const th = await initThInstance()
+
+    const serviceSteps = th.serviceSteps()
+
+    expect(serviceSteps).toBeInstanceOf(v1.ServiceSteps)
+
+    const { data } = await serviceSteps.get(serviceStepId)
+
+    expect(data).toMatchObject(serviceStep)
+  })
+
+  it('rejects on status codes that are not 200', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock
+        .onGet(`https://api.tillhub.com/api/v1/service-steps/${legacyId}/${serviceStepId}`)
+        .reply(() => {
+          return [205]
+        })
+    }
+
+    try {
+      const th = await initThInstance()
+      await th.serviceSteps().get(serviceStepId)
+    } catch (err: any) {
+      expect(err.name).toBe('ServiceStepFetchFailed')
+    }
+  })
+})

--- a/test/service_steps/meta.test.ts
+++ b/test/service_steps/meta.test.ts
@@ -1,0 +1,80 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { v1 } from '../../src/tillhub-js'
+import { initThInstance } from '../util'
+dotenv.config()
+
+const legacyId = '4564'
+
+describe('v1: ServiceSteps: can get count number of all service steps', () => {
+  const mock = new MockAdapter(axios)
+  afterEach(() => {
+    mock.reset()
+  })
+
+  it("Tillhub's service steps are instantiable", async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock.onGet(`https://api.tillhub.com/api/v1/service-steps/${legacyId}/meta`).reply(() => {
+        return [
+          200,
+          {
+            count: 50,
+            results: [{ count: 50 }]
+          }
+        ]
+      })
+    }
+
+    const th = await initThInstance()
+
+    const serviceSteps = th.serviceSteps()
+
+    expect(serviceSteps).toBeInstanceOf(v1.ServiceSteps)
+
+    const { data } = await serviceSteps.meta()
+
+    expect(data).toEqual([{ count: 50 }])
+  })
+
+  it('rejects on status codes that are not 200', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock.onGet(`https://api.tillhub.com/api/v1/service-steps/${legacyId}/meta`).reply(() => {
+        return [205]
+      })
+    }
+
+    try {
+      const th = await initThInstance()
+      await th.serviceSteps().meta()
+    } catch (err: any) {
+      expect(err.name).toBe('ServiceStepsMetaFailed')
+    }
+  })
+})

--- a/test/service_steps/put.test.ts
+++ b/test/service_steps/put.test.ts
@@ -1,0 +1,91 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { v1 } from '../../src/tillhub-js'
+import { initThInstance } from '../util'
+dotenv.config()
+
+const legacyId = '4564'
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+const serviceStepId = '0505ce68-9cd9-4b0c-ac5c-7cb6804e8956'
+const serviceStep = {
+  name: 'Hair coloring (edited)',
+  duration: 35
+}
+
+describe('v1: ServiceSteps: can alter a service step', () => {
+  it("Tillhub's service steps are instantiable", async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock
+        .onPut(`https://api.tillhub.com/api/v1/service-steps/${legacyId}/${serviceStepId}`)
+        .reply(() => {
+          return [
+            200,
+            {
+              count: 1,
+              results: [serviceStep]
+            }
+          ]
+        })
+    }
+
+    const th = await initThInstance()
+
+    const serviceSteps = th.serviceSteps()
+
+    expect(serviceSteps).toBeInstanceOf(v1.ServiceSteps)
+
+    const { data } = await serviceSteps.put(serviceStepId, serviceStep)
+
+    expect(data).toMatchObject(serviceStep)
+  })
+
+  it('rejects on errored response', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock
+        .onPut(`https://api.tillhub.com/api/v1/service-steps/${legacyId}/${serviceStepId}`)
+        .reply(() => {
+          return [500]
+        })
+    }
+
+    const th = await initThInstance()
+
+    try {
+      await th.serviceSteps().put(serviceStepId, serviceStep)
+    } catch (err: any) {
+      expect(err.name).toBe('ServiceStepPutFailed')
+    }
+  })
+})


### PR DESCRIPTION
Add the v1 `ServiceSteps` resource for the new Reservations > Service Steps section in tillhub-dashboard (UNTIL-20270). Mirrors `v0.StaffGroups` CRUD shape with v1 path conventions (`/api/v1/service-steps/:tenantId`).

Surface:
- ServiceSteps class with getAll / meta / get / put / create / delete
- ServiceStep entity type (name, duration, services, services_count, audit + soft-delete timestamps)
- ServiceStepLinkedService nested type for `services[]` summaries
- ServiceStepsQuery with q / limit / uri / deleted
- Dedicated error classes per operation, matching StaffGroups naming
- `serviceSteps()` factory on TillhubClient

Tests under test/service_steps/ mirror test/staff_groups/ — 6 files, 13 cases, including a delete-blocked (409) case exercising the `blocking_services` payload that the dashboard form surfaces as an inline alert.