### PR TITLE
feat(UNTIL-20313): add SMS v1 service-categories and services clients

### DIFF
--- a/src/tillhub-js.ts
+++ b/src/tillhub-js.ts
@@ -1242,6 +1242,22 @@ export class TillhubClient extends events.EventEmitter {
   }
 
   /**
+   * Create an authenticated ServiceCategories (SMS v1) instance
+   *
+   */
+  serviceCategories (): v1.ServiceCategories {
+    return this.generateAuthenticatedInstance(v1.ServiceCategories)
+  }
+
+  /**
+   * Create an authenticated Services (SMS v1) instance
+   *
+   */
+  servicesV1 (): v1.Services {
+    return this.generateAuthenticatedInstance(v1.Services)
+  }
+
+  /**
    * Create an authenticated Exports instance
    *
    */

--- a/src/v1/index.ts
+++ b/src/v1/index.ts
@@ -28,6 +28,8 @@ import { ContentTemplates } from './content-templates'
 import { Import } from './import'
 import { SuppliersProductsRelation } from './suppliers_products_relation'
 import { ServiceSteps } from './service_steps'
+import { ServiceCategories } from './service_categories'
+import { Services } from './services'
 
 export {
   Auth,
@@ -60,7 +62,9 @@ export {
   ContentTemplates,
   Import,
   SuppliersProductsRelation,
-  ServiceSteps
+  ServiceSteps,
+  ServiceCategories,
+  Services
 }
 
 export interface AnalyticsHandlersV1Types {

--- a/src/v1/service_categories.ts
+++ b/src/v1/service_categories.ts
@@ -1,0 +1,194 @@
+import { Client } from '../client'
+import { UriHelper } from '../uri-helper'
+import { BaseError } from '../errors/baseError'
+import { ThBaseHandler } from '../base'
+
+export interface ServiceCategoriesOptions {
+  user?: string
+  base?: string
+}
+
+export interface ServiceCategoriesQuery {
+  q?: string
+  limit?: number
+  offset?: number
+  uri?: string
+  active?: boolean
+  deleted?: boolean
+  branchId?: string
+}
+
+export interface ServiceCategoriesResponse {
+  data: ServiceCategory[]
+  metadata: Record<string, unknown>
+}
+
+export interface ServiceCategoryResponse {
+  data?: ServiceCategory
+  metadata?: {
+    count?: number
+  }
+  msg?: string
+}
+
+export interface ServiceCategory {
+  id?: string
+  name: string
+  description?: string | null
+  active?: boolean
+  createdAt?: string
+  updatedAt?: string
+  deletedAt?: string | null
+}
+
+export class ServiceCategories extends ThBaseHandler {
+  public static baseEndpoint = '/api/v1/service-categories'
+  endpoint: string
+  http: Client
+  public options: ServiceCategoriesOptions
+  public uriHelper: UriHelper
+
+  constructor (options: ServiceCategoriesOptions, http: Client) {
+    super(http, {
+      endpoint: ServiceCategories.baseEndpoint,
+      base: options.base ?? 'https://api.tillhub.com'
+    })
+    this.options = options
+    this.http = http
+
+    this.endpoint = ServiceCategories.baseEndpoint
+    this.options.base = this.options.base ?? 'https://api.tillhub.com'
+    this.uriHelper = new UriHelper(this.endpoint, this.options)
+  }
+
+  async getAll (query?: ServiceCategoriesQuery | undefined): Promise<ServiceCategoriesResponse> {
+    try {
+      const base = this.uriHelper.generateBaseUri()
+      const uri = this.uriHelper.generateUriWithQuery(base, query)
+
+      const response = await this.http.getClient().get(uri)
+
+      return {
+        data: response.data.results,
+        metadata: { count: response.data.results?.length, cursors: response.data.cursors }
+      }
+    } catch (error: any) {
+      throw new ServiceCategoriesFetchAllFailed(error.message, { error })
+    }
+  }
+
+  async get (serviceCategoryId: string): Promise<ServiceCategoryResponse> {
+    const uri = this.uriHelper.generateBaseUri(`/${serviceCategoryId}`)
+    try {
+      const response = await this.http.getClient().get(uri)
+      if (response.status !== 200) {
+        throw new ServiceCategoryFetchFailed(undefined, { status: response.status })
+      }
+
+      return {
+        data: response.data.results[0] as ServiceCategory,
+        msg: response.data.msg,
+        metadata: { count: response.data.count }
+      }
+    } catch (error: any) {
+      throw new ServiceCategoryFetchFailed(error.message, { error })
+    }
+  }
+
+  async create (serviceCategory: ServiceCategory): Promise<ServiceCategoryResponse> {
+    const uri = this.uriHelper.generateBaseUri()
+    try {
+      const response = await this.http.getClient().post(uri, serviceCategory)
+
+      return {
+        data: response.data.results[0] as ServiceCategory,
+        metadata: { count: response.data.count }
+      }
+    } catch (error: any) {
+      throw new ServiceCategoryCreationFailed(error.message, { error })
+    }
+  }
+
+  async put (serviceCategoryId: string, serviceCategory: ServiceCategory): Promise<ServiceCategoryResponse> {
+    const uri = this.uriHelper.generateBaseUri(`/${serviceCategoryId}`)
+    try {
+      const response = await this.http.getClient().put(uri, serviceCategory)
+
+      return {
+        data: response.data.results[0] as ServiceCategory,
+        metadata: { count: response.data.count }
+      }
+    } catch (error: any) {
+      throw new ServiceCategoryPutFailed(error.message, { error })
+    }
+  }
+
+  async delete (serviceCategoryId: string): Promise<ServiceCategoryResponse> {
+    const uri = this.uriHelper.generateBaseUri(`/${serviceCategoryId}`)
+    try {
+      const response = await this.http.getClient().delete(uri)
+      if (response.status !== 200) throw new ServiceCategoryDeleteFailed()
+
+      return {
+        msg: response.data.msg
+      }
+    } catch (error: any) {
+      throw new ServiceCategoryDeleteFailed(error.message, { error })
+    }
+  }
+}
+
+export class ServiceCategoriesFetchAllFailed extends BaseError {
+  public name = 'ServiceCategoriesFetchAllFailed'
+  constructor (
+    public message: string = 'Could not fetch all service categories',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, ServiceCategoriesFetchAllFailed.prototype)
+  }
+}
+
+export class ServiceCategoryFetchFailed extends BaseError {
+  public name = 'ServiceCategoryFetchFailed'
+  constructor (
+    public message: string = 'Could not fetch the service category',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, ServiceCategoryFetchFailed.prototype)
+  }
+}
+
+export class ServiceCategoryCreationFailed extends BaseError {
+  public name = 'ServiceCategoryCreationFailed'
+  constructor (
+    public message: string = 'Could not create the service category',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, ServiceCategoryCreationFailed.prototype)
+  }
+}
+
+export class ServiceCategoryPutFailed extends BaseError {
+  public name = 'ServiceCategoryPutFailed'
+  constructor (
+    public message: string = 'Could not alter the service category',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, ServiceCategoryPutFailed.prototype)
+  }
+}
+
+export class ServiceCategoryDeleteFailed extends BaseError {
+  public name = 'ServiceCategoryDeleteFailed'
+  constructor (
+    public message: string = 'Could not delete the service category',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, ServiceCategoryDeleteFailed.prototype)
+  }
+}

--- a/src/v1/services.ts
+++ b/src/v1/services.ts
@@ -1,0 +1,199 @@
+import { Client } from '../client'
+import { UriHelper } from '../uri-helper'
+import { BaseError } from '../errors/baseError'
+import { ThBaseHandler } from '../base'
+
+export interface ServicesOptions {
+  user?: string
+  base?: string
+}
+
+export interface ServicesQuery {
+  q?: string
+  limit?: number
+  offset?: number
+  uri?: string
+  active?: boolean
+  deleted?: boolean
+  serviceCategoryId?: string
+}
+
+export interface ServicesResponse {
+  data: Service[]
+  metadata: Record<string, unknown>
+}
+
+export interface ServiceResponse {
+  data?: Service
+  metadata?: {
+    count?: number
+  }
+  msg?: string
+}
+
+export interface Service {
+  id?: string
+  name: string
+  description?: string | null
+  duration: number
+  linkedProductId: string
+  bookableOnline?: boolean
+  serviceCategoryId?: string | null
+  locations?: string[] | null
+  active?: boolean
+  createdAt?: string
+  updatedAt?: string
+  deletedAt?: string | null
+}
+
+export class Services extends ThBaseHandler {
+  public static baseEndpoint = '/api/v1/services'
+  endpoint: string
+  http: Client
+  public options: ServicesOptions
+  public uriHelper: UriHelper
+
+  constructor (options: ServicesOptions, http: Client) {
+    super(http, {
+      endpoint: Services.baseEndpoint,
+      base: options.base ?? 'https://api.tillhub.com'
+    })
+    this.options = options
+    this.http = http
+
+    this.endpoint = Services.baseEndpoint
+    this.options.base = this.options.base ?? 'https://api.tillhub.com'
+    this.uriHelper = new UriHelper(this.endpoint, this.options)
+  }
+
+  async getAll (query?: ServicesQuery | undefined): Promise<ServicesResponse> {
+    try {
+      const base = this.uriHelper.generateBaseUri()
+      const uri = this.uriHelper.generateUriWithQuery(base, query)
+
+      const response = await this.http.getClient().get(uri)
+
+      return {
+        data: response.data.results,
+        metadata: { count: response.data.results?.length, cursors: response.data.cursors }
+      }
+    } catch (error: any) {
+      throw new ServicesFetchAllFailed(error.message, { error })
+    }
+  }
+
+  async get (serviceId: string): Promise<ServiceResponse> {
+    const uri = this.uriHelper.generateBaseUri(`/${serviceId}`)
+    try {
+      const response = await this.http.getClient().get(uri)
+      if (response.status !== 200) {
+        throw new ServiceFetchFailed(undefined, { status: response.status })
+      }
+
+      return {
+        data: response.data.results[0] as Service,
+        msg: response.data.msg,
+        metadata: { count: response.data.count }
+      }
+    } catch (error: any) {
+      throw new ServiceFetchFailed(error.message, { error })
+    }
+  }
+
+  async create (service: Service): Promise<ServiceResponse> {
+    const uri = this.uriHelper.generateBaseUri()
+    try {
+      const response = await this.http.getClient().post(uri, service)
+
+      return {
+        data: response.data.results[0] as Service,
+        metadata: { count: response.data.count }
+      }
+    } catch (error: any) {
+      throw new ServiceCreationFailed(error.message, { error })
+    }
+  }
+
+  async put (serviceId: string, service: Service): Promise<ServiceResponse> {
+    const uri = this.uriHelper.generateBaseUri(`/${serviceId}`)
+    try {
+      const response = await this.http.getClient().put(uri, service)
+
+      return {
+        data: response.data.results[0] as Service,
+        metadata: { count: response.data.count }
+      }
+    } catch (error: any) {
+      throw new ServicePutFailed(error.message, { error })
+    }
+  }
+
+  async delete (serviceId: string): Promise<ServiceResponse> {
+    const uri = this.uriHelper.generateBaseUri(`/${serviceId}`)
+    try {
+      const response = await this.http.getClient().delete(uri)
+      if (response.status !== 200) throw new ServiceDeleteFailed()
+
+      return {
+        msg: response.data.msg
+      }
+    } catch (error: any) {
+      throw new ServiceDeleteFailed(error.message, { error })
+    }
+  }
+}
+
+export class ServicesFetchAllFailed extends BaseError {
+  public name = 'ServicesFetchAllFailed'
+  constructor (
+    public message: string = 'Could not fetch all services',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, ServicesFetchAllFailed.prototype)
+  }
+}
+
+export class ServiceFetchFailed extends BaseError {
+  public name = 'ServiceFetchFailed'
+  constructor (
+    public message: string = 'Could not fetch the service',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, ServiceFetchFailed.prototype)
+  }
+}
+
+export class ServiceCreationFailed extends BaseError {
+  public name = 'ServiceCreationFailed'
+  constructor (
+    public message: string = 'Could not create the service',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, ServiceCreationFailed.prototype)
+  }
+}
+
+export class ServicePutFailed extends BaseError {
+  public name = 'ServicePutFailed'
+  constructor (
+    public message: string = 'Could not alter the service',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, ServicePutFailed.prototype)
+  }
+}
+
+export class ServiceDeleteFailed extends BaseError {
+  public name = 'ServiceDeleteFailed'
+  constructor (
+    public message: string = 'Could not delete the service',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, ServiceDeleteFailed.prototype)
+  }
+}

--- a/test/service_categories_v1/create.test.ts
+++ b/test/service_categories_v1/create.test.ts
@@ -1,0 +1,85 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { v1 } from '../../src/tillhub-js'
+import { initThInstance } from '../util'
+dotenv.config()
+
+const legacyId = '4564'
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+const serviceCategory = {
+  name: 'Haircut',
+  description: 'Haircut services'
+}
+
+describe('v1: ServiceCategories: can create one service category', () => {
+  it("Tillhub's service categories are instantiable", async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock.onPost(`https://api.tillhub.com/api/v1/service-categories/${legacyId}`).reply(() => {
+        return [
+          200,
+          {
+            count: 1,
+            results: [serviceCategory]
+          }
+        ]
+      })
+    }
+
+    const th = await initThInstance()
+
+    const serviceCategories = th.serviceCategories()
+
+    expect(serviceCategories).toBeInstanceOf(v1.ServiceCategories)
+
+    const { data } = await serviceCategories.create(serviceCategory)
+
+    expect(data).toMatchObject(serviceCategory)
+  })
+
+  it('rejects on errored response', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock.onPost(`https://api.tillhub.com/api/v1/service-categories/${legacyId}`).reply(() => {
+        return [500]
+      })
+    }
+
+    try {
+      const th = await initThInstance()
+      await th.serviceCategories().create(serviceCategory)
+    } catch (err: any) {
+      expect(err.name).toBe('ServiceCategoryCreationFailed')
+    }
+  })
+})

--- a/test/service_categories_v1/delete.test.ts
+++ b/test/service_categories_v1/delete.test.ts
@@ -1,0 +1,86 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { v1 } from '../../src/tillhub-js'
+import { initThInstance } from '../util'
+dotenv.config()
+
+const legacyId = '4564'
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+const serviceCategoryId = 'asdf5566'
+const respMsg = `Deleted service category ${serviceCategoryId}`
+
+describe('v1: ServiceCategories: can delete a service category', () => {
+  it("Tillhub's service categories are instantiable", async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock
+        .onDelete(`https://api.tillhub.com/api/v1/service-categories/${legacyId}/${serviceCategoryId}`)
+        .reply(() => {
+          return [
+            200,
+            {
+              msg: respMsg
+            }
+          ]
+        })
+    }
+
+    const th = await initThInstance()
+
+    const serviceCategories = th.serviceCategories()
+
+    expect(serviceCategories).toBeInstanceOf(v1.ServiceCategories)
+
+    const { msg } = await serviceCategories.delete(serviceCategoryId)
+
+    expect(msg).toEqual(respMsg)
+  })
+
+  it('rejects on errored response', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+      mock
+        .onDelete(`https://api.tillhub.com/api/v1/service-categories/${legacyId}/${serviceCategoryId}`)
+        .reply(() => {
+          return [500]
+        })
+    }
+
+    const th = await initThInstance()
+
+    try {
+      await th.serviceCategories().delete(serviceCategoryId)
+    } catch (err: any) {
+      expect(err.name).toBe('ServiceCategoryDeleteFailed')
+    }
+  })
+})

--- a/test/service_categories_v1/get-all.test.ts
+++ b/test/service_categories_v1/get-all.test.ts
@@ -1,0 +1,87 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { v1 } from '../../src/tillhub-js'
+import { initThInstance } from '../util'
+dotenv.config()
+
+const legacyId = '4564'
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+const serviceCategory = {
+  id: 'a3a7d4f6-3b6f-4f6e-9b1a-1c3d6e8f9a0b',
+  name: 'Haircut',
+  description: 'Haircut services',
+  active: true
+}
+
+describe('v1: ServiceCategories: can get all', () => {
+  it("Tillhub's ServiceCategories are instantiable", async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock.onGet(`https://api.tillhub.com/api/v1/service-categories/${legacyId}`).reply(() => {
+        return [
+          200,
+          {
+            count: 1,
+            results: [serviceCategory]
+          }
+        ]
+      })
+    }
+
+    const th = await initThInstance()
+
+    const serviceCategories = th.serviceCategories()
+
+    expect(serviceCategories).toBeInstanceOf(v1.ServiceCategories)
+
+    const { data } = await serviceCategories.getAll()
+
+    expect(Array.isArray(data)).toBe(true)
+  })
+
+  it('rejects on errored response', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+      mock.onGet(`https://api.tillhub.com/api/v1/service-categories/${legacyId}`).reply(() => {
+        return [500]
+      })
+    }
+
+    const th = await initThInstance()
+
+    try {
+      await th.serviceCategories().getAll()
+    } catch (err: any) {
+      expect(err.name).toBe('ServiceCategoriesFetchAllFailed')
+    }
+  })
+})

--- a/test/service_categories_v1/get.test.ts
+++ b/test/service_categories_v1/get.test.ts
@@ -1,0 +1,92 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { v1 } from '../../src/tillhub-js'
+import { initThInstance } from '../util'
+dotenv.config()
+
+const legacyId = '4564'
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+const serviceCategoryId = 'f8314183-8199-4cb7-b152-04f6ad4ebc7e'
+const serviceCategory = {
+  id: serviceCategoryId,
+  name: 'Haircut',
+  description: 'Haircut services',
+  active: true
+}
+
+describe('v1: ServiceCategories: can get one service category', () => {
+  it("Tillhub's service categories are instantiable", async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock
+        .onGet(`https://api.tillhub.com/api/v1/service-categories/${legacyId}/${serviceCategoryId}`)
+        .reply(() => {
+          return [
+            200,
+            {
+              count: 1,
+              results: [serviceCategory]
+            }
+          ]
+        })
+    }
+
+    const th = await initThInstance()
+
+    const serviceCategories = th.serviceCategories()
+
+    expect(serviceCategories).toBeInstanceOf(v1.ServiceCategories)
+
+    const { data } = await serviceCategories.get(serviceCategoryId)
+
+    expect(data).toMatchObject(serviceCategory)
+  })
+
+  it('rejects on status codes that are not 200', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock
+        .onGet(`https://api.tillhub.com/api/v1/service-categories/${legacyId}/${serviceCategoryId}`)
+        .reply(() => {
+          return [205]
+        })
+    }
+
+    try {
+      const th = await initThInstance()
+      await th.serviceCategories().get(serviceCategoryId)
+    } catch (err: any) {
+      expect(err.name).toBe('ServiceCategoryFetchFailed')
+    }
+  })
+})

--- a/test/service_categories_v1/put.test.ts
+++ b/test/service_categories_v1/put.test.ts
@@ -1,0 +1,90 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { v1 } from '../../src/tillhub-js'
+import { initThInstance } from '../util'
+dotenv.config()
+
+const legacyId = '4564'
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+const serviceCategoryId = '0505ce68-9cd9-4b0c-ac5c-7cb6804e8956'
+const serviceCategory = {
+  name: 'Haircut (edited)',
+  description: 'Updated haircut services'
+}
+
+describe('v1: ServiceCategories: can alter a service category', () => {
+  it("Tillhub's service categories are instantiable", async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock
+        .onPut(`https://api.tillhub.com/api/v1/service-categories/${legacyId}/${serviceCategoryId}`)
+        .reply(() => {
+          return [
+            200,
+            {
+              count: 1,
+              results: [serviceCategory]
+            }
+          ]
+        })
+    }
+
+    const th = await initThInstance()
+
+    const serviceCategories = th.serviceCategories()
+
+    expect(serviceCategories).toBeInstanceOf(v1.ServiceCategories)
+
+    const { data } = await serviceCategories.put(serviceCategoryId, serviceCategory)
+
+    expect(data).toMatchObject(serviceCategory)
+  })
+
+  it('rejects on errored response', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock
+        .onPut(`https://api.tillhub.com/api/v1/service-categories/${legacyId}/${serviceCategoryId}`)
+        .reply(() => {
+          return [500]
+        })
+    }
+
+    try {
+      const th = await initThInstance()
+      await th.serviceCategories().put(serviceCategoryId, serviceCategory)
+    } catch (err: any) {
+      expect(err.name).toBe('ServiceCategoryPutFailed')
+    }
+  })
+})

--- a/test/services_v1/create.test.ts
+++ b/test/services_v1/create.test.ts
@@ -1,0 +1,87 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { v1 } from '../../src/tillhub-js'
+import { initThInstance } from '../util'
+dotenv.config()
+
+const legacyId = '4564'
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+const service = {
+  name: 'Hair coloring',
+  duration: 30,
+  linkedProductId: 'p-1',
+  bookableOnline: true
+}
+
+describe('v1: Services: can create one service', () => {
+  it("Tillhub's services are instantiable", async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock.onPost(`https://api.tillhub.com/api/v1/services/${legacyId}`).reply(() => {
+        return [
+          200,
+          {
+            count: 1,
+            results: [service]
+          }
+        ]
+      })
+    }
+
+    const th = await initThInstance()
+
+    const services = th.servicesV1()
+
+    expect(services).toBeInstanceOf(v1.Services)
+
+    const { data } = await services.create(service)
+
+    expect(data).toMatchObject(service)
+  })
+
+  it('rejects on errored response', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock.onPost(`https://api.tillhub.com/api/v1/services/${legacyId}`).reply(() => {
+        return [500]
+      })
+    }
+
+    try {
+      const th = await initThInstance()
+      await th.servicesV1().create(service)
+    } catch (err: any) {
+      expect(err.name).toBe('ServiceCreationFailed')
+    }
+  })
+})

--- a/test/services_v1/delete.test.ts
+++ b/test/services_v1/delete.test.ts
@@ -1,0 +1,86 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { v1 } from '../../src/tillhub-js'
+import { initThInstance } from '../util'
+dotenv.config()
+
+const legacyId = '4564'
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+const serviceId = 'asdf5566'
+const respMsg = `Deleted service ${serviceId}`
+
+describe('v1: Services: can delete a service', () => {
+  it("Tillhub's services are instantiable", async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock
+        .onDelete(`https://api.tillhub.com/api/v1/services/${legacyId}/${serviceId}`)
+        .reply(() => {
+          return [
+            200,
+            {
+              msg: respMsg
+            }
+          ]
+        })
+    }
+
+    const th = await initThInstance()
+
+    const services = th.servicesV1()
+
+    expect(services).toBeInstanceOf(v1.Services)
+
+    const { msg } = await services.delete(serviceId)
+
+    expect(msg).toEqual(respMsg)
+  })
+
+  it('rejects on errored response', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+      mock
+        .onDelete(`https://api.tillhub.com/api/v1/services/${legacyId}/${serviceId}`)
+        .reply(() => {
+          return [500]
+        })
+    }
+
+    const th = await initThInstance()
+
+    try {
+      await th.servicesV1().delete(serviceId)
+    } catch (err: any) {
+      expect(err.name).toBe('ServiceDeleteFailed')
+    }
+  })
+})

--- a/test/services_v1/get-all.test.ts
+++ b/test/services_v1/get-all.test.ts
@@ -1,0 +1,89 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { v1 } from '../../src/tillhub-js'
+import { initThInstance } from '../util'
+dotenv.config()
+
+const legacyId = '4564'
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+const service = {
+  id: 'a3a7d4f6-3b6f-4f6e-9b1a-1c3d6e8f9a0b',
+  name: 'Hair coloring',
+  duration: 30,
+  linkedProductId: 'p-1',
+  bookableOnline: true,
+  serviceCategoryId: 'c-1'
+}
+
+describe('v1: Services: can get all', () => {
+  it("Tillhub's Services are instantiable", async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock.onGet(`https://api.tillhub.com/api/v1/services/${legacyId}`).reply(() => {
+        return [
+          200,
+          {
+            count: 1,
+            results: [service]
+          }
+        ]
+      })
+    }
+
+    const th = await initThInstance()
+
+    const services = th.servicesV1()
+
+    expect(services).toBeInstanceOf(v1.Services)
+
+    const { data } = await services.getAll()
+
+    expect(Array.isArray(data)).toBe(true)
+  })
+
+  it('rejects on errored response', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+      mock.onGet(`https://api.tillhub.com/api/v1/services/${legacyId}`).reply(() => {
+        return [500]
+      })
+    }
+
+    const th = await initThInstance()
+
+    try {
+      await th.servicesV1().getAll()
+    } catch (err: any) {
+      expect(err.name).toBe('ServicesFetchAllFailed')
+    }
+  })
+})

--- a/test/services_v1/get.test.ts
+++ b/test/services_v1/get.test.ts
@@ -1,0 +1,94 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { v1 } from '../../src/tillhub-js'
+import { initThInstance } from '../util'
+dotenv.config()
+
+const legacyId = '4564'
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+const serviceId = 'f8314183-8199-4cb7-b152-04f6ad4ebc7e'
+const service = {
+  id: serviceId,
+  name: 'Hair coloring',
+  duration: 30,
+  linkedProductId: 'p-1',
+  bookableOnline: true,
+  serviceCategoryId: 'c-1'
+}
+
+describe('v1: Services: can get one service', () => {
+  it("Tillhub's services are instantiable", async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock
+        .onGet(`https://api.tillhub.com/api/v1/services/${legacyId}/${serviceId}`)
+        .reply(() => {
+          return [
+            200,
+            {
+              count: 1,
+              results: [service]
+            }
+          ]
+        })
+    }
+
+    const th = await initThInstance()
+
+    const services = th.servicesV1()
+
+    expect(services).toBeInstanceOf(v1.Services)
+
+    const { data } = await services.get(serviceId)
+
+    expect(data).toMatchObject(service)
+  })
+
+  it('rejects on status codes that are not 200', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock
+        .onGet(`https://api.tillhub.com/api/v1/services/${legacyId}/${serviceId}`)
+        .reply(() => {
+          return [205]
+        })
+    }
+
+    try {
+      const th = await initThInstance()
+      await th.servicesV1().get(serviceId)
+    } catch (err: any) {
+      expect(err.name).toBe('ServiceFetchFailed')
+    }
+  })
+})

--- a/test/services_v1/put.test.ts
+++ b/test/services_v1/put.test.ts
@@ -1,0 +1,92 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { v1 } from '../../src/tillhub-js'
+import { initThInstance } from '../util'
+dotenv.config()
+
+const legacyId = '4564'
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+const serviceId = '0505ce68-9cd9-4b0c-ac5c-7cb6804e8956'
+const service = {
+  name: 'Hair coloring (edited)',
+  duration: 35,
+  linkedProductId: 'p-1',
+  bookableOnline: false
+}
+
+describe('v1: Services: can alter a service', () => {
+  it("Tillhub's services are instantiable", async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock
+        .onPut(`https://api.tillhub.com/api/v1/services/${legacyId}/${serviceId}`)
+        .reply(() => {
+          return [
+            200,
+            {
+              count: 1,
+              results: [service]
+            }
+          ]
+        })
+    }
+
+    const th = await initThInstance()
+
+    const services = th.servicesV1()
+
+    expect(services).toBeInstanceOf(v1.Services)
+
+    const { data } = await services.put(serviceId, service)
+
+    expect(data).toMatchObject(service)
+  })
+
+  it('rejects on errored response', async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+        return [
+          200,
+          {
+            token: '',
+            user: {
+              id: '123',
+              legacy_id: legacyId
+            }
+          }
+        ]
+      })
+
+      mock
+        .onPut(`https://api.tillhub.com/api/v1/services/${legacyId}/${serviceId}`)
+        .reply(() => {
+          return [500]
+        })
+    }
+
+    try {
+      const th = await initThInstance()
+      await th.servicesV1().put(serviceId, service)
+    } catch (err: any) {
+      expect(err.name).toBe('ServicePutFailed')
+    }
+  })
+})


### PR DESCRIPTION
## What

Adds two SMS (Reservations) v1 SDK clients used by the dashboard service-management migration ([UNTIL-20313](https://unz.atlassian.net/browse/UNTIL-20313)):

- **`v1.ServiceCategories`** → `/api/v1/service-categories` — exposed as `th.serviceCategories()`
- **`v1.Services`** → `/api/v1/services` — exposed as `th.servicesV1()` (`services()` is the existing v0 client, so the SMS one is version-suffixed, matching `productsV2`/`productsV4`)

Both implement `getAll / get / create / put / delete` and read the SMS success envelope (`{ msg, results, status }`). They mirror the existing `v1.ServiceSteps` client, with the envelope handling corrected for SMS (reads `results`, no synthetic count/cursor).

## Why

The Reservations domain is moving Service & Service Category ownership from Main API v0 (`product_groups` / `products`) to SMS v1 (see parent [UNTIL-20261](https://unz.atlassian.net/browse/UNTIL-20261); backend shipped in tillhub-staff-management-service #427 and #432/#447). The dashboard needs these clients to read/write the new endpoints.

## Tests

`test/service_categories_v1/` and `test/services_v1/` — CRUD success + error cases per client (20 tests), mirroring the `service_steps` suite. `dist/` intentionally not committed (rebuilt by semantic-release on release).


[UNTIL-20313]: https://unz.atlassian.net/browse/UNTIL-20313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[UNTIL-20261]: https://unz.atlassian.net/browse/UNTIL-20261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ