### PR TITLE
feat(UNTIL-20476): embed step assignments on v1 Service interface

### DIFF
--- a/src/v1/services.ts
+++ b/src/v1/services.ts
@@ -2,6 +2,7 @@ import { Client } from '../client'
 import { UriHelper } from '../uri-helper'
 import { BaseError } from '../errors/baseError'
 import { ThBaseHandler } from '../base'
+import { ServiceStepAssignment } from './service_step_assignments'
 
 export interface ServicesOptions {
   user?: string
@@ -44,6 +45,7 @@ export interface Service {
   createdAt?: string
   updatedAt?: string
   deletedAt?: string | null
+  assignments?: ServiceStepAssignment[]
 }
 
 export class Services extends ThBaseHandler {


### PR DESCRIPTION
## Summary
- Add optional `assignments?: ServiceStepAssignment[]` to the v1 `Service` interface so step assignments can be read/written embedded on the service payload (instead of via the separate `/steps` endpoints).

## Context
- Supports dashboard work in UNTIL-20476, moving service management to the unified Service API with embedded step assignments.
- Backend contract: UNTIL-20333.

## Test plan
- [ ] Type-check passes
- [ ] Consuming dashboard branch compiles against the new field