### PR TITLE
feat(services): deprecate v0 services/serviceCategory getters & staff.getServices in favor of v1

### DIFF
--- a/src/tillhub-js.ts
+++ b/src/tillhub-js.ts
@@ -1228,6 +1228,8 @@ export class TillhubClient extends events.EventEmitter {
   /**
    * Create an authenticated ServiceCategory instance
    *
+   * @deprecated v0 deprecated, use the following v1 endpoint instead: {@link serviceCategories}
+   * (`/api/v1/service-categories`).
    */
   serviceCategory (): v0.ServiceCategory {
     return this.generateAuthenticatedInstance(v0.ServiceCategory)
@@ -1236,6 +1238,8 @@ export class TillhubClient extends events.EventEmitter {
   /**
    * Create an authenticated Services instance
    *
+   * @deprecated v0 deprecated, use the following v1 endpoint instead: {@link servicesV1}
+   * (`/api/v1/services`, service payload with embedded `steps[]`).
    */
   services (): v0.Services {
     return this.generateAuthenticatedInstance(v0.Services)

--- a/src/v0/service_category.ts
+++ b/src/v0/service_category.ts
@@ -25,6 +25,10 @@ export interface ServiceCategoryItem {
   deleted?: boolean
 }
 
+/**
+ * @deprecated v0 deprecated, use the following v1 endpoint instead: `th.serviceCategories()`
+ * (`/api/v1/service-categories`).
+ */
 export class ServiceCategory extends ThBaseHandler {
   public static baseEndpoint = '/api/v0/service_categories'
   endpoint: string

--- a/src/v0/services.ts
+++ b/src/v0/services.ts
@@ -32,6 +32,10 @@ export interface ServicesObject {
   bookable_online?: boolean
 }
 
+/**
+ * @deprecated v0 deprecated, use the following v1 endpoint instead: `th.servicesV1()`
+ * (`/api/v1/services`, service payload with embedded `steps[]`).
+ */
 export class Services extends ThBaseHandler {
   public static baseEndpoint = '/api/v0/services'
   endpoint: string

--- a/src/v0/staff.ts
+++ b/src/v0/staff.ts
@@ -363,6 +363,12 @@ export class Staff extends ThBaseHandler {
     }
   }
 
+  /**
+   * Fetch the reservation services assigned to a staff member.
+   *
+   * @deprecated v0 deprecated, use the following v1 endpoint instead: `th.servicesV1()`
+   * (`/api/v1/services`).
+   */
   async getServices (staffId: string): Promise<StaffServicesResponse> {
     try {
       const base = this.uriHelper.generateBaseUri(`/${staffId}/services`)


### PR DESCRIPTION
## What

Marks the legacy **v0 reservation service / service-category** SDK surface as `@deprecated`, pointing consumers at the `v1` classes that already exist in this SDK. Part of the "Services with Structured Work Steps" initiative (tech spec §3.2.1).

Jira: [UNTIL-20334](https://unz.atlassian.net/browse/UNTIL-20334)

## Changes (JSDoc `@deprecated` only — no behavior/signature changes)

- `src/tillhub-js.ts`: `services()` → use `servicesV1()`; `serviceCategory()` → use `serviceCategories()`.
- `src/v0/services.ts`: class `Services` deprecated → v1 `Services` (`th.servicesV1()`).
- `src/v0/service_category.ts`: class `ServiceCategory` deprecated → v1 `ServiceCategories` (`th.serviceCategories()`).
- `src/v0/staff.ts`: `getServices()` deprecated (reads `/api/v0/staff/:staffId/services`) → v1 services API.

The v1 replacement classes (`servicesV1()`, `serviceCategories()`, `serviceSteps()`) already ship in this SDK, so no new methods are added.

## Not changed

Catalog `products` (`th.products()`) and `productGroups` (`th.productGroups()`) classes are untouched.

## Verification

- Diff is JSDoc-comment-only across 4 files (`git diff` confirms no code/signature changes) → cannot affect compilation or runtime.
- Repo `node_modules` not installed locally, so `tsc`/`jest` were not run here; comment-only additions are safe by construction and CI will type-check/test on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[UNTIL-20334]: https://unz.atlassian.net/browse/UNTIL-20334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ