### PR TITLE
fix(UNTIL-20668): integration partners endpoint is not tenanted

### DIFF
--- a/src/v0/integration_partners.ts
+++ b/src/v0/integration_partners.ts
@@ -62,7 +62,9 @@ export class IntegrationPartners extends ThBaseHandler {
 
     this.endpoint = IntegrationPartners.baseEndpoint
     this.options.base = this.options.base ?? 'https://api.tillhub.com'
-    this.uriHelper = new UriHelper(this.endpoint, this.options)
+    // Integration partners is a global (non-tenanted) dictionary, so the
+    // authenticated user id must not be appended to the base URI.
+    this.uriHelper = new UriHelper(this.endpoint, { base: this.options.base })
   }
 
   private partnerPath (integrationPartnerId: string): string {

--- a/test/integration_partners/create.test.ts
+++ b/test/integration_partners/create.test.ts
@@ -22,7 +22,7 @@ const integrationPartner = {
   deletedAt: null
 }
 
-const listUrl = `https://api.tillhub.com/api/v0/integration-partners/${legacyId}`
+const listUrl = `https://api.tillhub.com/api/v0/integration-partners`
 
 describe('v0: IntegrationPartners: create', () => {
   it('is instantiable and posts a new integration partner', async () => {

--- a/test/integration_partners/delete.test.ts
+++ b/test/integration_partners/delete.test.ts
@@ -14,7 +14,7 @@ afterEach(() => {
   mock.reset()
 })
 
-const detailsUrl = `https://api.tillhub.com/api/v0/integration-partners/${legacyId}/${integrationPartnerId}`
+const detailsUrl = `https://api.tillhub.com/api/v0/integration-partners/${integrationPartnerId}`
 
 describe('v0: IntegrationPartners: delete', () => {
   it('is instantiable and deletes an integration partner (204)', async () => {

--- a/test/integration_partners/list-all.test.ts
+++ b/test/integration_partners/list-all.test.ts
@@ -22,7 +22,7 @@ const integrationPartner = {
   deletedAt: null
 }
 
-const listUrl = `https://api.tillhub.com/api/v0/integration-partners/${legacyId}`
+const listUrl = `https://api.tillhub.com/api/v0/integration-partners`
 
 describe('v0: IntegrationPartners: listAll', () => {
   it('aggregates all pages', async () => {

--- a/test/integration_partners/list.test.ts
+++ b/test/integration_partners/list.test.ts
@@ -22,7 +22,7 @@ const integrationPartner = {
   deletedAt: null
 }
 
-const listUrl = `https://api.tillhub.com/api/v0/integration-partners/${legacyId}`
+const listUrl = `https://api.tillhub.com/api/v0/integration-partners`
 const detailsUrl = `${listUrl}/${integrationPartnerId}`
 
 describe('v0: IntegrationPartners', () => {

--- a/test/integration_partners/restore.test.ts
+++ b/test/integration_partners/restore.test.ts
@@ -22,7 +22,7 @@ const restoredPartner = {
   deletedAt: null
 }
 
-const restoreUrl = `https://api.tillhub.com/api/v0/integration-partners/${legacyId}/${integrationPartnerId}/restore`
+const restoreUrl = `https://api.tillhub.com/api/v0/integration-partners/${integrationPartnerId}/restore`
 
 describe('v0: IntegrationPartners: restore', () => {
   it('is instantiable and restores a deleted integration partner', async () => {

--- a/test/integration_partners/update.test.ts
+++ b/test/integration_partners/update.test.ts
@@ -22,7 +22,7 @@ const updatedPartner = {
   deletedAt: null
 }
 
-const detailsUrl = `https://api.tillhub.com/api/v0/integration-partners/${legacyId}/${integrationPartnerId}`
+const detailsUrl = `https://api.tillhub.com/api/v0/integration-partners/${integrationPartnerId}`
 
 describe('v0: IntegrationPartners: update', () => {
   it('is instantiable and patches an existing integration partner', async () => {


### PR DESCRIPTION
## Problem
`th.integrationPartners()` requests were hitting `/api/v0/integration-partners/{tenantId}` and returning **404**. The integration partners dictionary is a **global, non-tenanted** resource — the correct path is `/api/v0/integration-partners` with no tenant segment.

The module built its `UriHelper` from the full options object (which includes the authenticated `user` id injected by `generateAuthenticatedInstance`), so `UriHelper` appended `/{user}` to the base URI.

## Fix
Construct the `UriHelper` with only `{ base }` (omitting `user`) so the tenant id is never appended. All verbs (`getAll`/`listAll`/`get`/`create`/`update`/`delete`/`restore`) now target the correct global path.

## Tests
Updated the 6 integration-partners test suites (they had encoded the buggy tenant-scoped URL). All 16 tests pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)