### PR TITLE
fix(UNTIL-20668): lint on integration partners test URLs

### DIFF
--- a/test/integration_partners/create.test.ts
+++ b/test/integration_partners/create.test.ts
@@ -22,7 +22,7 @@ const integrationPartner = {
   deletedAt: null
 }
 
-const listUrl = `https://api.tillhub.com/api/v0/integration-partners`
+const listUrl = 'https://api.tillhub.com/api/v0/integration-partners'
 
 describe('v0: IntegrationPartners: create', () => {
   it('is instantiable and posts a new integration partner', async () => {

--- a/test/integration_partners/list-all.test.ts
+++ b/test/integration_partners/list-all.test.ts
@@ -22,7 +22,7 @@ const integrationPartner = {
   deletedAt: null
 }
 
-const listUrl = `https://api.tillhub.com/api/v0/integration-partners`
+const listUrl = 'https://api.tillhub.com/api/v0/integration-partners'
 
 describe('v0: IntegrationPartners: listAll', () => {
   it('aggregates all pages', async () => {

--- a/test/integration_partners/list.test.ts
+++ b/test/integration_partners/list.test.ts
@@ -22,7 +22,7 @@ const integrationPartner = {
   deletedAt: null
 }
 
-const listUrl = `https://api.tillhub.com/api/v0/integration-partners`
+const listUrl = 'https://api.tillhub.com/api/v0/integration-partners'
 const detailsUrl = `${listUrl}/${integrationPartnerId}`
 
 describe('v0: IntegrationPartners', () => {


### PR DESCRIPTION
## Problem
The `Test` CI step (lint) is failing on `master` after #748:

```
test/integration_partners/create.test.ts   25:17  error  Strings must use singlequote  @typescript-eslint/quotes
test/integration_partners/list-all.test.ts 25:17  error  Strings must use singlequote  @typescript-eslint/quotes
test/integration_partners/list.test.ts     25:17  error  Strings must use singlequote  @typescript-eslint/quotes
```

When the tenant segment (`/${legacyId}`) was removed from these URLs, the template literals no longer had any interpolation, which violates `@typescript-eslint/quotes` (non-interpolated backtick strings must be single-quoted).

## Fix
Convert the three affected URLs from backtick template literals to single-quoted strings. No behavioral change.

## Tests
Lint clean; all 16 integration-partners tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)