### PR TITLE
feat(UNTIL-21688): add meta to v1 services and service categories

### DIFF
--- a/src/v1/service_categories.ts
+++ b/src/v1/service_categories.ts
@@ -18,9 +18,31 @@ export interface ServiceCategoriesQuery {
   branchId?: string
 }
 
+export interface ServiceCategoriesMetaQuery {
+  q?: string
+  limit?: number
+  offset?: number
+  uri?: string
+  active?: boolean
+  deleted?: boolean
+  branchId?: string
+  start?: string
+  end?: string
+  orderFields?: string[]
+}
+
 export interface ServiceCategoriesResponse {
   data: ServiceCategory[]
   metadata: Record<string, unknown>
+}
+
+export interface ServiceCategoriesMetaResponse {
+  data: {
+    count: number
+  }
+  metadata: {
+    count?: number
+  }
 }
 
 export interface ServiceCategoryResponse {
@@ -74,6 +96,29 @@ export class ServiceCategories extends ThBaseHandler {
       }
     } catch (error: any) {
       throw new ServiceCategoriesFetchAllFailed(error.message, { error })
+    }
+  }
+
+  async meta (q?: ServiceCategoriesMetaQuery | undefined): Promise<ServiceCategoriesMetaResponse> {
+    const base = this.uriHelper.generateBaseUri('/meta')
+    const uri = this.uriHelper.generateUriWithQuery(base, q)
+    try {
+      const response = await this.http.getClient().get(uri)
+      if (response.status !== 200) {
+        throw new ServiceCategoriesMetaFailed(undefined, { status: response.status })
+      }
+      if (!response.data.results?.[0]) {
+        throw new ServiceCategoriesMetaFailed('could not get service categories metadata unexpectedly', {
+          status: response.status
+        })
+      }
+
+      return {
+        data: response.data.results[0],
+        metadata: { count: response.data.count }
+      }
+    } catch (error: any) {
+      throw new ServiceCategoriesMetaFailed(error.message, { error })
     }
   }
 
@@ -146,6 +191,17 @@ export class ServiceCategoriesFetchAllFailed extends BaseError {
   ) {
     super(message, properties)
     Object.setPrototypeOf(this, ServiceCategoriesFetchAllFailed.prototype)
+  }
+}
+
+export class ServiceCategoriesMetaFailed extends BaseError {
+  public name = 'ServiceCategoriesMetaFailed'
+  constructor (
+    public message: string = 'Could not get service categories metadata',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, ServiceCategoriesMetaFailed.prototype)
   }
 }
 

--- a/src/v1/services.ts
+++ b/src/v1/services.ts
@@ -24,6 +24,22 @@ export interface ServicesQuery {
   id?: string[]
 }
 
+export interface ServicesMetaQuery {
+  q?: string
+  limit?: number
+  offset?: number
+  uri?: string
+  active?: boolean
+  deleted?: boolean
+  id?: string | string[]
+  serviceCategoryId?: string | string[]
+  linkedProductId?: string | string[]
+  locations?: string | string[]
+  start?: string
+  end?: string
+  orderFields?: string[]
+}
+
 const ServiceQueryBodyKeys = new Set<string>(['id'])
 
 export interface ServicesResponse {
@@ -38,6 +54,15 @@ export interface ServiceResponse {
     count?: number
   }
   msg?: string
+}
+
+export interface ServicesMetaResponse {
+  data: {
+    count: number
+  }
+  metadata: {
+    count?: number
+  }
 }
 
 export interface Service {
@@ -89,6 +114,29 @@ export class Services extends ThBaseHandler {
       }
     } catch (error: any) {
       throw new ServicesFetchAllFailed(error.message, { error })
+    }
+  }
+
+  async meta (q?: ServicesMetaQuery | undefined): Promise<ServicesMetaResponse> {
+    const base = this.uriHelper.generateBaseUri('/meta')
+    const uri = this.uriHelper.generateUriWithQuery(base, q)
+    try {
+      const response = await this.http.getClient().get(uri)
+      if (response.status !== 200) {
+        throw new ServicesMetaFailed(undefined, { status: response.status })
+      }
+      if (!response.data.results?.[0]) {
+        throw new ServicesMetaFailed('could not get services metadata unexpectedly', {
+          status: response.status
+        })
+      }
+
+      return {
+        data: response.data.results[0],
+        metadata: { count: response.data.count }
+      }
+    } catch (error: any) {
+      throw new ServicesMetaFailed(error.message, { error })
     }
   }
 
@@ -223,6 +271,17 @@ export class ServicesFetchAllFailed extends BaseError {
   ) {
     super(message, properties)
     Object.setPrototypeOf(this, ServicesFetchAllFailed.prototype)
+  }
+}
+
+export class ServicesMetaFailed extends BaseError {
+  public name = 'ServicesMetaFailed'
+  constructor (
+    public message: string = 'Could not get services metadata',
+    properties?: Record<string, unknown>
+  ) {
+    super(message, properties)
+    Object.setPrototypeOf(this, ServicesMetaFailed.prototype)
   }
 }
 

--- a/test/service_categories_v1/meta.test.ts
+++ b/test/service_categories_v1/meta.test.ts
@@ -1,0 +1,153 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { v1 } from '../../src/tillhub-js'
+import { initThInstance } from '../util'
+dotenv.config()
+
+const legacyId = '4564'
+const metaUri = `https://api.tillhub.com/api/v1/service-categories/${legacyId}/meta`
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+function mockLogin (): void {
+  mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+    return [
+      200,
+      {
+        token: '',
+        user: {
+          id: '123',
+          legacy_id: legacyId
+        }
+      }
+    ]
+  })
+}
+
+describe('v1: ServiceCategories: can get count of all service categories', () => {
+  it("Tillhub's ServiceCategories are instantiable", async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mockLogin()
+      mock.onGet(metaUri).reply(() => {
+        return [
+          200,
+          {
+            count: 1,
+            results: [{ count: 42 }]
+          }
+        ]
+      })
+    }
+
+    const th = await initThInstance()
+
+    const serviceCategories = th.serviceCategories()
+
+    expect(serviceCategories).toBeInstanceOf(v1.ServiceCategories)
+
+    const { data } = await serviceCategories.meta()
+
+    expect(data.count).toEqual(42)
+  })
+
+  it('passes the query on to the meta endpoint', async () => {
+    if (process.env.SYSTEM_TEST === 'true') return
+
+    mockLogin()
+
+    let requestedUrl: string | undefined
+    mock.onGet(new RegExp(`${metaUri}.*`)).reply((config) => {
+      requestedUrl = config.url
+      return [
+        200,
+        {
+          count: 1,
+          results: [{ count: 3 }]
+        }
+      ]
+    })
+
+    const th = await initThInstance()
+
+    const { data } = await th.serviceCategories().meta({
+      deleted: false,
+      branchId: 'b-1'
+    })
+
+    expect(data.count).toEqual(3)
+    expect(requestedUrl).toContain('deleted=false')
+    expect(requestedUrl).toContain('branchId=b-1')
+  })
+
+  it('rejects when the response contains no metadata', async () => {
+    if (process.env.SYSTEM_TEST === 'true') return
+
+    mockLogin()
+    mock.onGet(metaUri).reply(() => {
+      return [
+        200,
+        {
+          count: 0,
+          results: []
+        }
+      ]
+    })
+
+    const th = await initThInstance()
+
+    try {
+      await th.serviceCategories().meta()
+      fail('should have thrown')
+    } catch (err: any) {
+      expect(err.name).toBe('ServiceCategoriesMetaFailed')
+    }
+  })
+
+  // The body is intentionally valid here, so the rejection can only come from the
+  // status check and not from reading results off an empty response.
+  it('rejects on status codes that are not 200', async () => {
+    if (process.env.SYSTEM_TEST === 'true') return
+
+    mockLogin()
+    mock.onGet(metaUri).reply(() => {
+      return [
+        205,
+        {
+          count: 1,
+          results: [{ count: 5 }]
+        }
+      ]
+    })
+
+    const th = await initThInstance()
+
+    try {
+      await th.serviceCategories().meta()
+      fail('should have thrown')
+    } catch (err: any) {
+      expect(err.name).toBe('ServiceCategoriesMetaFailed')
+    }
+  })
+
+  it('rejects on errored response', async () => {
+    if (process.env.SYSTEM_TEST === 'true') return
+
+    mockLogin()
+    mock.onGet(metaUri).reply(() => {
+      return [500]
+    })
+
+    const th = await initThInstance()
+
+    try {
+      await th.serviceCategories().meta()
+      fail('should have thrown')
+    } catch (err: any) {
+      expect(err.name).toBe('ServiceCategoriesMetaFailed')
+    }
+  })
+})

--- a/test/services_v1/meta.test.ts
+++ b/test/services_v1/meta.test.ts
@@ -1,0 +1,155 @@
+import * as dotenv from 'dotenv'
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import { v1 } from '../../src/tillhub-js'
+import { initThInstance } from '../util'
+dotenv.config()
+
+const legacyId = '4564'
+const metaUri = `https://api.tillhub.com/api/v1/services/${legacyId}/meta`
+
+const mock = new MockAdapter(axios)
+afterEach(() => {
+  mock.reset()
+})
+
+function mockLogin (): void {
+  mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+    return [
+      200,
+      {
+        token: '',
+        user: {
+          id: '123',
+          legacy_id: legacyId
+        }
+      }
+    ]
+  })
+}
+
+describe('v1: Services: can get count of all services', () => {
+  it("Tillhub's Services are instantiable", async () => {
+    if (process.env.SYSTEM_TEST !== 'true') {
+      mockLogin()
+      mock.onGet(metaUri).reply(() => {
+        return [
+          200,
+          {
+            count: 1,
+            results: [{ count: 150 }]
+          }
+        ]
+      })
+    }
+
+    const th = await initThInstance()
+
+    const services = th.servicesV1()
+
+    expect(services).toBeInstanceOf(v1.Services)
+
+    const { data } = await services.meta()
+
+    expect(data.count).toEqual(150)
+  })
+
+  it('passes the query on to the meta endpoint', async () => {
+    if (process.env.SYSTEM_TEST === 'true') return
+
+    mockLogin()
+
+    let requestedUrl: string | undefined
+    mock.onGet(new RegExp(`${metaUri}.*`)).reply((config) => {
+      requestedUrl = config.url
+      return [
+        200,
+        {
+          count: 1,
+          results: [{ count: 7 }]
+        }
+      ]
+    })
+
+    const th = await initThInstance()
+
+    const { data } = await th.servicesV1().meta({
+      deleted: false,
+      serviceCategoryId: 'c-1',
+      q: 'hair'
+    })
+
+    expect(data.count).toEqual(7)
+    expect(requestedUrl).toContain('deleted=false')
+    expect(requestedUrl).toContain('serviceCategoryId=c-1')
+    expect(requestedUrl).toContain('q=hair')
+  })
+
+  it('rejects when the response contains no metadata', async () => {
+    if (process.env.SYSTEM_TEST === 'true') return
+
+    mockLogin()
+    mock.onGet(metaUri).reply(() => {
+      return [
+        200,
+        {
+          count: 0,
+          results: []
+        }
+      ]
+    })
+
+    const th = await initThInstance()
+
+    try {
+      await th.servicesV1().meta()
+      fail('should have thrown')
+    } catch (err: any) {
+      expect(err.name).toBe('ServicesMetaFailed')
+    }
+  })
+
+  // The body is intentionally valid here, so the rejection can only come from the
+  // status check and not from reading results off an empty response.
+  it('rejects on status codes that are not 200', async () => {
+    if (process.env.SYSTEM_TEST === 'true') return
+
+    mockLogin()
+    mock.onGet(metaUri).reply(() => {
+      return [
+        205,
+        {
+          count: 1,
+          results: [{ count: 5 }]
+        }
+      ]
+    })
+
+    const th = await initThInstance()
+
+    try {
+      await th.servicesV1().meta()
+      fail('should have thrown')
+    } catch (err: any) {
+      expect(err.name).toBe('ServicesMetaFailed')
+    }
+  })
+
+  it('rejects on errored response', async () => {
+    if (process.env.SYSTEM_TEST === 'true') return
+
+    mockLogin()
+    mock.onGet(metaUri).reply(() => {
+      return [500]
+    })
+
+    const th = await initThInstance()
+
+    try {
+      await th.servicesV1().meta()
+      fail('should have thrown')
+    } catch (err: any) {
+      expect(err.name).toBe('ServicesMetaFailed')
+    }
+  })
+})


### PR DESCRIPTION
## What

Adds a `meta()` method to the v1 `services` and `service-categories` resources, so consumers can fetch a real total count instead of deriving it from the length of the returned page.

Jira: [UNTIL-21688](https://unz.atlassian.net/browse/UNTIL-21688)

## Why

The Dashboard's Services and Service Categories list pages have the datatable meta (count) request disabled via `no-meta-check`, because these two resources expose no `meta()` method — leaving the check enabled made the datatable throw. As a result the displayed row count only ever reflects the current page, so the Services page total saturates at its page limit of 100.

The backend endpoints already exist and are documented in the API spec:

- `GET /api/v1/services/{tenantId}/meta`
- `GET /api/v1/service-categories/{tenantId}/meta`

Both accept the same filter params as their list counterparts and return `results: [{ count }]`. This PR is the SDK half; removing `no-meta-check` in the Dashboard follows once this is released and bumped.

## Changes

Additive only — no existing method or type was modified.

- `meta(q?)` on both resources, following the existing `products` / `customers` pattern: `/meta` base URI, query through `generateUriWithQuery`, guard on non-200, guard on missing `results[0]`, return `{ data: results[0], metadata: { count } }`.
- `ServicesMetaQuery` / `ServiceCategoriesMetaQuery`, typed to the params the endpoints actually document. The services variant also covers `linkedProductId` and `locations`, which `ServicesQuery` does not currently have.
- `ServicesMetaResponse` / `ServiceCategoriesMetaResponse`, so the count response is properly typed rather than reusing the list response types.
- `ServicesMetaFailed` / `ServiceCategoriesMetaFailed` error classes.

## Tests

Five cases per resource: happy path, query passthrough (asserts filters land in the request URL), empty `results`, non-200, and 500.

New tests pass (10), related suites pass (`services_v1`, `service_categories_v1`, `service_steps` — 19 suites / 47 tests). `eslint` and `tsc --noEmit` are clean.

## Note for the reviewer

I mutation-tested the status guard by deleting it, and the "rejects on non-200" case still passed: a bare `[205]` mock has no body, so `response.data.results` throws on property access and the rejection happens regardless of the guard. The mocks in these new tests therefore return a **valid body** alongside the 205, so rejection can only come from the status check — with that change, removing the guard does fail the test.

The same weakness exists in the pre-existing `test/service_steps/meta.test.ts` and probably in other `meta` tests derived from that template, meaning their status guards are effectively untested. Left alone here as out of scope, but it is a cheap sweep if wanted.

## Consumer follow-up

`meta()` returns `data` as `{ count: N }` (an object, via `results[0]`), not the `[{ count: N }]` array that `serviceSteps.meta()` returns. Both are handled by the Dashboard datatable, which branches on `Array.isArray`.

One thing that will not be fixed by simply dropping `no-meta-check`: the datatable skips the meta call whenever any filter is applied, so filtered and searched views will still show a page-scoped count. The `/meta` endpoints do accept the filter params, so opting in is possible — tracked as a decision on the ticket.


[UNTIL-21688]: https://unz.atlassian.net/browse/UNTIL-21688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ