### PR TITLE
feat(UNTIL-21688): return next cursor from v1 services and service ca…

### DIFF
--- a/src/v1/service_categories.ts
+++ b/src/v1/service_categories.ts
@@ -34,6 +34,7 @@ export interface ServiceCategoriesMetaQuery {
 export interface ServiceCategoriesResponse {
   data: ServiceCategory[]
   metadata: Record<string, unknown>
+  next?: () => Promise<ServiceCategoriesResponse>
 }
 
 export interface ServiceCategoriesMetaResponse {
@@ -84,15 +85,23 @@ export class ServiceCategories extends ThBaseHandler {
   }
 
   async getAll (query?: ServiceCategoriesQuery | undefined): Promise<ServiceCategoriesResponse> {
+    let next
+
     try {
       const base = this.uriHelper.generateBaseUri()
       const uri = this.uriHelper.generateUriWithQuery(base, query)
 
       const response = await this.http.getClient().get(uri)
 
+      if (response.data.cursors?.after) {
+        next = (): Promise<ServiceCategoriesResponse> =>
+          this.getAll({ uri: response.data.cursors.after })
+      }
+
       return {
         data: response.data.results,
-        metadata: { count: response.data.results?.length, cursors: response.data.cursors }
+        metadata: { count: response.data.results?.length, cursors: response.data.cursors },
+        next
       }
     } catch (error: any) {
       throw new ServiceCategoriesFetchAllFailed(error.message, { error })

--- a/src/v1/services.ts
+++ b/src/v1/services.ts
@@ -102,15 +102,23 @@ export class Services extends ThBaseHandler {
   }
 
   async getAll (query?: ServicesQuery | undefined): Promise<ServicesResponse> {
+    let next
+
     try {
       const base = this.uriHelper.generateBaseUri()
       const uri = this.uriHelper.generateUriWithQuery(base, query)
 
       const response = await this.http.getClient().get(uri)
 
+      if (response.data.cursors?.after) {
+        next = (): Promise<ServicesResponse> =>
+          this.getAll({ uri: response.data.cursors.after })
+      }
+
       return {
         data: response.data.results,
-        metadata: { count: response.data.results?.length, cursors: response.data.cursors }
+        metadata: { count: response.data.results?.length, cursors: response.data.cursors },
+        next
       }
     } catch (error: any) {
       throw new ServicesFetchAllFailed(error.message, { error })

--- a/test/service_categories_v1/get-all.test.ts
+++ b/test/service_categories_v1/get-all.test.ts
@@ -57,6 +57,76 @@ describe('v1: ServiceCategories: can get all', () => {
     expect(Array.isArray(data)).toBe(true)
   })
 
+  it('exposes no next when there is no cursors.after', async () => {
+    if (process.env.SYSTEM_TEST === 'true') return
+
+    mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+      return [200, { token: '', user: { id: '123', legacy_id: legacyId } }]
+    })
+    mock
+      .onGet(`https://api.tillhub.com/api/v1/service-categories/${legacyId}`)
+      .reply(() => {
+        return [
+          200,
+          {
+            results: [serviceCategory],
+            cursors: { before: null, after: null }
+          }
+        ]
+      })
+
+    const th = await initThInstance()
+
+    const firstPage = await th.serviceCategories().getAll()
+
+    expect(firstPage.next).toBeUndefined()
+  })
+
+  it('follows cursors.after via next', async () => {
+    if (process.env.SYSTEM_TEST === 'true') return
+
+    const cursorAfter = `https://api.tillhub.com/api/v1/service-categories/${legacyId}?cursor=abc`
+
+    mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+      return [200, { token: '', user: { id: '123', legacy_id: legacyId } }]
+    })
+    mock
+      .onGet(new RegExp(`/api/v1/service-categories/${legacyId}`))
+      .reply((config) => {
+        if (String(config.url).includes('cursor=abc')) {
+          return [
+            200,
+            {
+              results: [{ ...serviceCategory, id: 'cat-2' }],
+              cursors: { before: null, after: null }
+            }
+          ]
+        }
+
+        return [
+          200,
+          {
+            results: [serviceCategory],
+            cursors: { before: null, after: cursorAfter }
+          }
+        ]
+      })
+
+    const th = await initThInstance()
+
+    const firstPage = await th.serviceCategories().getAll({ deleted: false })
+
+    expect(firstPage.data).toHaveLength(1)
+    expect(typeof firstPage.next).toBe('function')
+    expect(firstPage.metadata).toMatchObject({ cursors: { after: cursorAfter } })
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const secondPage = await firstPage.next!()
+
+    expect(secondPage.data).toEqual([{ ...serviceCategory, id: 'cat-2' }])
+    expect(secondPage.next).toBeUndefined()
+  })
+
   it('rejects on errored response', async () => {
     if (process.env.SYSTEM_TEST !== 'true') {
       mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {

--- a/test/services_v1/get-all.test.ts
+++ b/test/services_v1/get-all.test.ts
@@ -59,6 +59,72 @@ describe('v1: Services: can get all', () => {
     expect(Array.isArray(data)).toBe(true)
   })
 
+  it('exposes no next when there is no cursors.after', async () => {
+    if (process.env.SYSTEM_TEST === 'true') return
+
+    mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+      return [200, { token: '', user: { id: '123', legacy_id: legacyId } }]
+    })
+    mock.onGet(`https://api.tillhub.com/api/v1/services/${legacyId}`).reply(() => {
+      return [
+        200,
+        {
+          results: [service],
+          cursors: { before: null, after: null }
+        }
+      ]
+    })
+
+    const th = await initThInstance()
+
+    const firstPage = await th.servicesV1().getAll()
+
+    expect(firstPage.next).toBeUndefined()
+  })
+
+  it('follows cursors.after via next', async () => {
+    if (process.env.SYSTEM_TEST === 'true') return
+
+    const cursorAfter = `https://api.tillhub.com/api/v1/services/${legacyId}?cursor=abc`
+
+    mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {
+      return [200, { token: '', user: { id: '123', legacy_id: legacyId } }]
+    })
+    mock.onGet(new RegExp(`/api/v1/services/${legacyId}`)).reply((config) => {
+      if (String(config.url).includes('cursor=abc')) {
+        return [
+          200,
+          {
+            results: [{ ...service, id: 'svc-2' }],
+            cursors: { before: null, after: null }
+          }
+        ]
+      }
+
+      return [
+        200,
+        {
+          results: [service],
+          cursors: { before: null, after: cursorAfter }
+        }
+      ]
+    })
+
+    const th = await initThInstance()
+
+    const firstPage = await th.servicesV1().getAll({ deleted: false })
+
+    expect(firstPage.data).toHaveLength(1)
+    expect(typeof firstPage.next).toBe('function')
+    expect(firstPage.metadata).toMatchObject({ cursors: { after: cursorAfter } })
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const secondPage = await firstPage.next!()
+
+    expect(secondPage.data).toEqual([{ ...service, id: 'svc-2' }])
+    expect(secondPage.next).toBeUndefined()
+  })
+
   it('rejects on errored response', async () => {
     if (process.env.SYSTEM_TEST !== 'true') {
       mock.onPost('https://api.tillhub.com/api/v0/users/login').reply(() => {


### PR DESCRIPTION
## What

Returns a `next` cursor from `getAll` on the v1 `services` and `service-categories` resources.

Jira: [UNTIL-21688](https://unz.atlassian.net/browse/UNTIL-21688)

## Why

`meta()` (added in #754) gives consumers a real total count, but a count only tells a table how many pages to *draw* — it hands over no rows. The dashboard datatable, for tables not using `offset-pagination`, never re-fetches on page change; it slices its local buffer, and the only way that buffer can grow is by calling `next()`.

Because v1 `getAll` returned no `next`, a table with a real count of 250 would draw 13 pages while holding only the first 100 rows — the later pages rendered blank. `meta()` alone therefore made the symptom worse, not better.

The endpoints already return `cursors: { before, after }`; `getAll` was reading them into `metadata` and otherwise ignoring them. This surfaces them as a `next` function.

## Changes

- `getAll` builds `next` when `cursors.after` is present, mirroring the existing `query()` implementation in the same file and `v0/documents.ts`:

  ```ts
  if (response.data.cursors?.after) {
    next = (): Promise<ServicesResponse> =>
      this.getAll({ uri: response.data.cursors.after })
  }
  ```

- `ServiceCategoriesResponse` gains `next?: () => Promise<ServiceCategoriesResponse>` (`ServicesResponse` already declared it).

No existing behaviour changed — `data` and `metadata` are returned exactly as before.

## Tests

Two cases per resource:
- `next` is `undefined` when `cursors.after` is null
- `next` follows the cursor URI, returns the following page, and the terminal page exposes no further `next`

38 tests pass across both suites; ESLint and `tsc --noEmit` clean.

Mutation-checked: deleting the cursor block makes `follows cursors.after via next` fail, so the test is not vacuous.

## Contract assumption worth knowing

`next` passes only `{ uri: cursors.after }`, dropping the original query — this assumes the backend encodes the full query (filters, limit) into the cursor URI. That is the same assumption `v0/documents.ts` has relied on in production, but it was verified here only against mocks, not the live v1 endpoints. If it does not hold, a filtered consumer would get unfiltered rows on page 2.


[UNTIL-21688]: https://unz.atlassian.net/browse/UNTIL-21688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ